### PR TITLE
fix: SSG post content prerender for AI search

### DIFF
--- a/src/__tests__/utils/blog.test.ts
+++ b/src/__tests__/utils/blog.test.ts
@@ -52,7 +52,7 @@ describe('Blog Utils', () => {
   });
 
   describe('getTableOfContents', () => {
-    it('헤더 블록들을 올바르게 추출한다', () => {
+    it('H1/H2 헤더 블록만 추출하고 H3는 제외한다', () => {
       const mockPageBlock = {
         id: 'page-id',
         type: 'page',
@@ -135,13 +135,6 @@ describe('Blog Utils', () => {
             id: 'subheader1',
             title: '두 번째 헤더',
             level: 2,
-            children: [
-              {
-                id: 'subsubheader1',
-                title: '세 번째 헤더',
-                level: 3,
-              },
-            ],
           },
         ],
       });

--- a/src/components/ui/blog/PostBody/PostBody.test.tsx
+++ b/src/components/ui/blog/PostBody/PostBody.test.tsx
@@ -14,7 +14,6 @@ vi.mock('react-notion-x', () => ({
     recordMap,
     disableHeader,
     fullPage,
-    ...props
   }: {
     recordMap: ExtendedRecordMap;
     disableHeader?: boolean;
@@ -24,11 +23,14 @@ vi.mock('react-notion-x', () => ({
     if (!recordMap || Object.keys(recordMap.block || {}).length === 0) {
       return <div data-testid="notion-renderer-empty">Empty content</div>;
     }
+    // recordMap에 circular reference가 있어 직렬화 가능한 필드만 노출
+    const safeProps = {
+      fullPage,
+      disableHeader,
+      hasRecordMap: !!recordMap,
+    };
     return (
-      <div
-        data-testid="notion-renderer"
-        data-props={JSON.stringify({ recordMap, disableHeader, fullPage, ...props })}
-      >
+      <div data-testid="notion-renderer" data-props={JSON.stringify(safeProps)}>
         Mocked Notion Content
       </div>
     );

--- a/src/components/ui/blog/PostBody/PostBody.tsx
+++ b/src/components/ui/blog/PostBody/PostBody.tsx
@@ -57,6 +57,10 @@ import 'katex/dist/katex.min.css';
 // 아래 third-party는 사용 빈도가 낮거나 브라우저 전용이라 dynamic으로 코드 스플리팅 유지
 const Code = dynamic(() => import('react-notion-x/build/third-party/code').then(m => m.Code));
 
+const Collection = dynamic(() =>
+  import('react-notion-x/build/third-party/collection').then(m => m.Collection),
+);
+
 const Equation = dynamic(() =>
   import('react-notion-x/build/third-party/equation').then(m => m.Equation),
 );
@@ -114,6 +118,7 @@ export function PostBody({ recordMap, className = '' }: PostBodyProps) {
         disableHeader={true}
         components={{
           Code,
+          Collection,
           Equation,
           Modal,
           Pdf,

--- a/src/components/ui/blog/PostBody/PostBody.tsx
+++ b/src/components/ui/blog/PostBody/PostBody.tsx
@@ -10,6 +10,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ExtendedRecordMap } from 'notion-types';
 import React from 'react';
+import { NotionRenderer } from 'react-notion-x';
 
 // Prism.js core import 먼저
 import 'prismjs';
@@ -46,24 +47,14 @@ import 'prismjs/components/prism-swift.js';
 import 'prismjs/components/prism-wasm.js';
 import 'prismjs/components/prism-yaml.js';
 
-import { useThemeStore } from '@/store/themeStore';
-
 // Notion 렌더러 관련 스타일 import
 import '@/styles/notion.css';
 import 'prismjs/themes/prism-tomorrow.css';
 import '@/styles/prism-theme.css';
 import 'katex/dist/katex.min.css';
 
-// 각 컴포넌트를 개별적으로 dynamic import
-const NotionRenderer = dynamic(() => import('react-notion-x').then(m => m.NotionRenderer), {
-  ssr: false,
-  loading: () => (
-    <div className="flex items-center justify-center py-8">
-      <div className="text-gray-500">콘텐츠를 불러오는 중...</div>
-    </div>
-  ),
-});
-
+// 본문은 SSG 시점에 HTML로 직렬화되어야 AI 크롤러와 SEO에 노출됨 → top-level import
+// 아래 third-party는 사용 빈도가 낮거나 브라우저 전용이라 dynamic으로 코드 스플리팅 유지
 const Code = dynamic(() => import('react-notion-x/build/third-party/code').then(m => m.Code));
 
 const Equation = dynamic(() =>
@@ -102,8 +93,6 @@ export interface PostBodyProps {
  * react-notion-x를 사용하여 Notion 블록들을 HTML로 변환
  */
 export function PostBody({ recordMap, className = '' }: PostBodyProps) {
-  const { theme } = useThemeStore();
-
   // recordMap이 없거나 비어있는 경우
   if (!recordMap) {
     return (
@@ -113,12 +102,15 @@ export function PostBody({ recordMap, className = '' }: PostBodyProps) {
     );
   }
 
+  // darkMode prop은 의도적으로 넘기지 않음
+  // SSG 시점엔 사용자 테마를 알 수 없으므로 light-mode 클래스로 prerender되고
+  // 실제 다크/라이트 색상은 root `[data-theme]` 속성 + notion.css 변수로 제어됨
+  // (FOUC 방지 스크립트가 paint 전에 data-theme를 설정하므로 깜빡임 없음)
   return (
     <div className={`${className}`}>
       <NotionRenderer
         recordMap={recordMap}
         fullPage={true}
-        darkMode={theme === 'dark'}
         disableHeader={true}
         components={{
           Code,

--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -66,7 +66,7 @@
   --notion-header-height: 45px;
 }
 
-.dark-mode {
+[data-theme='dark'] {
   --fg-color: rgba(255, 255, 255, 0.9);
   --fg-color-0: var(--fg-color);
   --fg-color-1: var(--fg-color);
@@ -1117,7 +1117,7 @@ svg.notion-page-icon {
   border: 1px solid var(--fg-color-0);
 }
 
-.dark-mode .notion-callout {
+[data-theme='dark'] .notion-callout {
   border-color: var(--bg-color-2);
 }
 

--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -1717,9 +1717,7 @@ svg.notion-page-icon {
 }
 
 .notion-collection-page-properties {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
+  display: none;
 }
 
 .notion-table-of-contents {

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -71,17 +71,17 @@ export function normalizeNotionId(id: string): string {
 
 /**
  * Notion 페이지에서 목차를 생성합니다
- * H1(header), H2(sub_header), H3(sub_sub_header) 블록을 파싱하여 계층 구조를 생성합니다
+ * H1(header), H2(sub_header) 블록만 파싱하여 계층 구조를 생성합니다
+ * (H3/sub_sub_header는 목차에서 제외)
  */
 export function getTableOfContents(
   page: PageBlock,
   recordMap: ExtendedRecordMap,
 ): TableOfContentsItem[] {
-  // 헤더 타입별 레벨 매핑
+  // 헤더 타입별 레벨 매핑 (sub_sub_header는 의도적으로 제외)
   const indentLevels = {
     header: 1,
     sub_header: 2,
-    sub_sub_header: 3,
   } as const;
 
   type MapResult = { id: string; title: string; level: 1 | 2 | 3 } | null | MapResult[];
@@ -94,7 +94,7 @@ export function getTableOfContents(
       if (block) {
         const { type } = block;
 
-        if (type === 'header' || type === 'sub_header' || type === 'sub_sub_header') {
+        if (type === 'header' || type === 'sub_header') {
           return {
             id: normalizeNotionId(blockId), // Notion 렌더링에서 하이픈이 제거되므로 ToC ID도 하이픈 제거
             title: getTextContent(block.properties?.title) || UNTITLED_FALLBACK_TITLE,


### PR DESCRIPTION
## Summary
- 블로그 포스트 본문을 SSG 시점에 HTML로 직렬화하여 AI 크롤러와 SEO에 노출되도록 변경
- ToC에서 h3 태그 제거 및 다크 모드 CSS 리팩터링
- `react-notion-x`의 `Collection` 컴포넌트를 dynamic import로 등록하여 `"using empty component Collection"` 경고 해소
- Collection 등록 후 노출되던 Notion 페이지 properties(category, createdAt, tag 등)를 `.notion-collection-page-properties { display: none }` 으로 숨김 처리

## Test plan
- [ ] `bun run build` 통과 확인
- [ ] `bun run test:unit:run` 통과 확인
- [ ] 블로그 포스트 페이지에서 본문 HTML이 SSR/SSG로 직렬화되어 노출되는지 확인
- [ ] 콘솔에서 `using empty component "Collection"` 경고가 더 이상 출력되지 않는지 확인
- [ ] Notion 페이지 properties 메타데이터가 본문 상단에 노출되지 않는지 확인
- [ ] 라이트/다크 모드 전환 시 색상 깜빡임 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)