### PR TITLE
feat(seo): improve AI crawler friendliness (JSON-LD, RSS, llms.txt)

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import type { ExtendedRecordMap, PageBlock } from 'notion-types';
 import { getBlockValue } from 'notion-utils';
 
 import { getPageBlocks } from '@/libs/notionClient';
-import { generatePostMetadata } from '@/libs/seo/postMetadata';
+import { generatePostJsonLd, generatePostMetadata } from '@/libs/seo/postMetadata';
 import { getPostListWithStaticFallback } from '@/libs/staticPostData';
 import type { PostMeta } from '@/types/blog';
 import { findPostByEncodedSlug, getTableOfContents } from '@/utils/blog';
@@ -119,34 +119,52 @@ export default async function PostPage({ params }: PostPageProps) {
     const postsPerPage = 5;
     const enablePagination = relatedPosts.length > postsPerPage;
 
+    const siteConfig = getSiteConfig();
+    const jsonLd = generatePostJsonLd({
+      title: post.title,
+      description: post.description || '',
+      ogImage: post.cover || undefined,
+      canonical: `/blog/${post.slug}`,
+      keywords: post.tags,
+      publishedTime: post.createdAt,
+      modifiedTime: post.lastEditedAt,
+      author: siteConfig.author.name,
+    });
+
     return (
-      <PostPageContent
-        post={{
-          ...post,
-          createdAt: post.createdAt,
-        }}
-        recordMap={recordMap}
-        prevPost={
-          prevPost
-            ? {
-                title: prevPost.title,
-                href: `/blog/${prevPost.encodedSlug || prevPost.slug}`, // 인코딩된 slug 우선 사용
-              }
-            : undefined
-        }
-        nextPost={
-          nextPost
-            ? {
-                title: nextPost.title,
-                href: `/blog/${nextPost.encodedSlug || nextPost.slug}`, // 인코딩된 slug 우선 사용
-              }
-            : undefined
-        }
-        relatedPosts={relatedPosts}
-        showRelatedPosts={relatedPosts.length > 0}
-        enableRelatedPostsPagination={enablePagination}
-        tableOfContents={tableOfContents}
-      />
+      <>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+        <PostPageContent
+          post={{
+            ...post,
+            createdAt: post.createdAt,
+          }}
+          recordMap={recordMap}
+          prevPost={
+            prevPost
+              ? {
+                  title: prevPost.title,
+                  href: `/blog/${prevPost.encodedSlug || prevPost.slug}`, // 인코딩된 slug 우선 사용
+                }
+              : undefined
+          }
+          nextPost={
+            nextPost
+              ? {
+                  title: nextPost.title,
+                  href: `/blog/${nextPost.encodedSlug || nextPost.slug}`, // 인코딩된 slug 우선 사용
+                }
+              : undefined
+          }
+          relatedPosts={relatedPosts}
+          showRelatedPosts={relatedPosts.length > 0}
+          enableRelatedPostsPagination={enablePagination}
+          tableOfContents={tableOfContents}
+        />
+      </>
     );
   } catch (error) {
     console.error('Error rendering post page:', error);

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+
+import { SITE_CONFIG, AUTHOR_CONFIG } from '@/constants';
+import { getStaticPostList } from '@/libs/staticPostData';
+
+export const dynamic = 'force-static';
+
+/**
+ * RSS 2.0 feed.xml 생성
+ *
+ * AI 크롤러/리더가 신규 글을 자동으로 발견할 수 있도록 RSS feed 제공
+ */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET() {
+  const baseUrl = SITE_CONFIG.url;
+  const posts = getStaticPostList();
+  const buildDate = new Date().toUTCString();
+
+  const items = posts
+    .map(post => {
+      const link = `${baseUrl}/blog/${post.slug}/`;
+      const pubDate = new Date(post.lastEditedAt || post.createdAt).toUTCString();
+      const categories = post.tags.map(tag => `<category>${escapeXml(tag)}</category>`).join('');
+      return [
+        '    <item>',
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${link}</link>`,
+        `      <guid isPermaLink="true">${link}</guid>`,
+        `      <pubDate>${pubDate}</pubDate>`,
+        `      <description>${escapeXml(post.description || '')}</description>`,
+        `      <author>${escapeXml(AUTHOR_CONFIG.email)} (${escapeXml(AUTHOR_CONFIG.name)})</author>`,
+        categories ? `      ${categories}` : '',
+        '    </item>',
+      ]
+        .filter(Boolean)
+        .join('\n');
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(SITE_CONFIG.name)}</title>
+    <link>${baseUrl}</link>
+    <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml" />
+    <description>${escapeXml(SITE_CONFIG.description)}</description>
+    <language>ko-KR</language>
+    <lastBuildDate>${buildDate}</lastBuildDate>
+${items}
+  </channel>
+</rss>
+`;
+
+  return new NextResponse(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+
+import { SITE_CONFIG, AUTHOR_CONFIG } from '@/constants';
+import { getStaticPostList } from '@/libs/staticPostData';
+
+export const dynamic = 'force-static';
+
+/**
+ * llms.txt 생성 (llmstxt.org 표준)
+ *
+ * AI 크롤러가 사이트를 효율적으로 인덱싱하도록 핵심 메타데이터와
+ * 우선 순위가 높은 콘텐츠 목록을 평문 마크다운으로 제공
+ */
+export async function GET() {
+  const baseUrl = SITE_CONFIG.url;
+  const posts = getStaticPostList();
+
+  const postLines = posts
+    .map(post => {
+      const url = `${baseUrl}/blog/${post.slug}/`;
+      const description = post.description?.replace(/\s+/g, ' ').trim() || post.title;
+      return `- [${post.title}](${url}): ${description}`;
+    })
+    .join('\n');
+
+  const body = `# ${SITE_CONFIG.name}
+
+> ${SITE_CONFIG.description} 저자 ${AUTHOR_CONFIG.name} (${AUTHOR_CONFIG.position}, ${AUTHOR_CONFIG.team}).
+
+## About
+
+- [About](${baseUrl}/about/): 저자 소개와 관심 주제
+- [Blog](${baseUrl}/blog/): 모든 블로그 포스트 목록
+- [Sitemap](${baseUrl}/sitemap.xml): 전체 URL 목록
+- [Feed](${baseUrl}/feed.xml): RSS 2.0 피드
+
+## Posts
+
+${postLines}
+`;
+
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -20,5 +20,6 @@ export default function robots(): MetadataRoute.Robots {
       disallow: ['/private/', '/admin/'], // 필요시 제외할 경로 추가
     },
     sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
+    host: SITE_CONFIG.url,
   };
 }

--- a/src/libs/seo/postMetadata.ts
+++ b/src/libs/seo/postMetadata.ts
@@ -3,6 +3,68 @@ import type { Metadata } from 'next';
 import { SITE_CONFIG, AUTHOR_CONFIG } from '@/constants';
 
 /**
+ * BlogPosting JSON-LD 생성을 위한 입력
+ */
+export interface PostJsonLdInput extends PostMetadataProps {
+  /** 절대 URL 형태의 정규 URL (필수) */
+  canonical: string;
+}
+
+/**
+ * schema.org/BlogPosting JSON-LD 객체 생성
+ *
+ * AI 크롤러(GPTBot, ClaudeBot 등)와 검색 엔진이 구조화된 메타데이터로
+ * 글의 제목, 저자, 발행일 등을 안정적으로 인식하도록 돕습니다.
+ * 페이지 컴포넌트에서 `<script type="application/ld+json">`으로 직렬화해 주입하세요.
+ */
+export function generatePostJsonLd({
+  title,
+  description,
+  ogImage = '/og-image.png',
+  canonical,
+  keywords = [],
+  publishedTime,
+  modifiedTime,
+  author,
+}: PostJsonLdInput): Record<string, unknown> {
+  const authorName = author || AUTHOR_CONFIG.name;
+  const siteUrl = SITE_CONFIG.url;
+  const absoluteOgImage = ogImage?.startsWith('http') ? ogImage : `${siteUrl}${ogImage}`;
+  const absoluteCanonical = canonical.startsWith('http') ? canonical : `${siteUrl}${canonical}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': absoluteCanonical,
+    },
+    headline: title,
+    description,
+    image: [absoluteOgImage],
+    datePublished: publishedTime,
+    dateModified: modifiedTime || publishedTime,
+    author: {
+      '@type': 'Person',
+      name: authorName,
+      url: siteUrl,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: SITE_CONFIG.name,
+      url: siteUrl,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${siteUrl}/og-image.png`,
+      },
+    },
+    keywords: keywords.join(', '),
+    inLanguage: 'ko-KR',
+    url: absoluteCanonical,
+  };
+}
+
+/**
  * 블로그 포스트의 SEO 메타데이터 생성을 위한 Props 인터페이스
  */
 export interface PostMetadataProps {


### PR DESCRIPTION
## Summary
AI 크롤러(ChatGPT, ClaudeBot, Perplexity 등)와 검색 엔진이 블로그 포스트를 더 잘 인식·인덱싱하도록 SEO/Discovery 레이어를 보강합니다.

- **JSON-LD BlogPosting schema 추가** — 포스트 페이지에 `<script type="application/ld+json">`을 주입해 schema.org/BlogPosting 구조화 데이터를 노출. AI/검색 엔진이 휴리스틱이 아닌 표준 메타데이터로 글의 제목·저자·발행일을 안정적으로 파싱할 수 있음.
- **RSS feed (`/feed.xml`)** — 피드 수집 봇과 RAG 파이프라인이 신규 글을 증분으로 발견할 수 있도록 RSS 2.0 피드를 정적 생성.
- **llms.txt (`/llms.txt`)** — [llmstxt.org](https://llmstxt.org) 표준을 따라 사이트 핵심 정보와 전체 포스트 목록을 평문 마크다운으로 제공. AI 크롤러가 가볍게 인덱싱 가능.
- **robots.txt에 host 디렉티브** — 정규 호스트 명시.

## Why
이전 조사에서 일부 AI fetch 도구(특히 Claude.ai web fetch)가 약 1.18MB짜리 포스트 페이지(RSC payload 포함)의 본문 추출에 실패하는 케이스가 확인됨. 이번 PR은 페이로드 다이어트와는 별개로, **구조화 데이터·feed·llms.txt를 통해 AI 크롤러가 본문 HTML에 의존하지 않고도 사이트와 콘텐츠를 발견·이해할 수 있는 채널**을 확보합니다. RSC payload 슬림화는 별도 PR로 진행 예정.

## Commits
1. `feat(seo): add BlogPosting JSON-LD to blog post pages` — `generatePostJsonLd` 추가 + 페이지 주입
2. `feat(seo): add RSS feed at /feed.xml` — 정적 RSS 2.0 라우트
3. `feat(seo): add llms.txt for AI crawler guidance` — llmstxt.org 표준 라우트
4. `chore(seo): declare host directive in robots.txt`

## Test plan
- [ ] `bun run lint:check` — 통과 (0 errors)
- [ ] `bun run types:check` — 통과
- [ ] `bun run test:unit:run` — 652 tests 통과
- [ ] 배포 후 `/blog/[slug]/` 페이지 소스에서 `<script type="application/ld+json">` 확인
- [ ] 배포 후 `curl https://r3gardless.dev/feed.xml` 결과가 valid RSS 2.0 인지 확인
- [ ] 배포 후 `curl https://r3gardless.dev/llms.txt` 결과 확인
- [ ] [Schema.org Validator](https://validator.schema.org/) 또는 [Rich Results Test](https://search.google.com/test/rich-results)로 JSON-LD 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)