### PR TITLE
Handle duplicate reference source links

### DIFF
--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -219,6 +219,18 @@ function checkReferenceSourceWikilinks(
         );
       }
     }
+
+    for (const match of section.matchAll(
+      /\[([^\]\n]+)\]\(([^)\s]+)\)\s*[—-]\s*\[(원문|original)\]\(([^)]+)\)/gi,
+    )) {
+      const [, label, href, , originalHref] = match;
+
+      if (href === originalHref) {
+        errors.push(
+          `${relativeFile}: reference "${label}" duplicates the same source_url as a trailing 원문 link.`,
+        );
+      }
+    }
   }
 }
 

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -208,6 +208,10 @@ function checkRenderedPost(post: PostMeta, errors: string[]) {
   if (html.includes('**<a') || html.includes('</a>**')) {
     errors.push(`Post "${post.slug}" leaked escaped bold markers around a rendered link.`);
   }
+
+  if (features.references && html.includes('reference-card-title">원문')) {
+    errors.push(`Post "${post.slug}" rendered duplicate 원문 reference bookmark cards.`);
+  }
 }
 
 function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {

--- a/src/__tests__/libs/content/exporter.test.ts
+++ b/src/__tests__/libs/content/exporter.test.ts
@@ -55,6 +55,10 @@ describe('content exporter', () => {
     expect(result.markdown).toContain('[second](/blog/second-note)');
     expect(result.markdown).toContain('[source](https://www.youtube.com/watch?v=fixture)');
     expect(result.markdown).toContain('[YouTube Source](https://www.youtube.com/watch?v=fixture)');
+    expect(result.markdown).not.toContain(
+      '[YouTube Source](https://www.youtube.com/watch?v=fixture) — [원문](https://www.youtube.com/watch?v=fixture)',
+    );
+    expect(result.markdown).not.toContain('[원문](https://www.youtube.com/watch?v=fixture)');
     expect(result.markdown).toContain('**[[youtube-source|PostgreSQL 자체 Git 저장소]]**');
     expect(result.markdown).not.toContain(
       '\\*\\*[[youtube-source|PostgreSQL 자체 Git 저장소]]\\*\\*',

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -291,6 +291,23 @@ Normal link to [Product Quantization](https://doi.org/10.1109/TPAMI.2010.57).
     expect(container.querySelectorAll('.reference-card-list-item')).toHaveLength(2);
   });
 
+  it('collapses duplicate original links in reference sections to one bookmark card', async () => {
+    const content = await renderMarkdownToReact(`# Reference Dedup Fixture
+
+# 참고문헌
+
+- [YouTube Source](https://www.youtube.com/watch?v=fixture) — [원문](https://www.youtube.com/watch?v=fixture)
+`);
+
+    const { container } = render(<>{content}</>);
+    const referenceCards = container.querySelectorAll('.reference-card');
+
+    expect(referenceCards).toHaveLength(1);
+    expect(referenceCards[0]).toHaveAttribute('href', 'https://www.youtube.com/watch?v=fixture');
+    expect(referenceCards[0]).toHaveTextContent('YouTube Source');
+    expect(referenceCards[0]).not.toHaveTextContent('원문');
+  });
+
   it('keeps consecutive h2 and h3 headings as separate blockable elements', async () => {
     const content = await renderMarkdownToReact(`## 3. PQ 논문 정리
 

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -294,6 +294,57 @@ function transformReferenceSourceWikilinks(tree: Root, index: ContentIndex) {
   }
 }
 
+function isLinkNode(value: unknown): value is Link {
+  return Boolean(
+    value && typeof value === 'object' && (value as { type?: unknown }).type === 'link',
+  );
+}
+
+function isTextNode(value: unknown): value is Text {
+  return Boolean(
+    value && typeof value === 'object' && (value as { type?: unknown }).type === 'text',
+  );
+}
+
+function isReferenceOriginalLabel(value: string): boolean {
+  return /^(원문|original)$/i.test(value.trim());
+}
+
+function removeDuplicateReferenceOriginalLinks(tree: Root) {
+  const referenceChildren = collectReferenceSectionChildren(tree);
+
+  if (referenceChildren.size === 0) {
+    return;
+  }
+
+  for (const child of referenceChildren) {
+    visit(child as Node, 'paragraph', node => {
+      const paragraph = node as Parent;
+
+      for (let index = 0; index < paragraph.children.length - 2; index += 1) {
+        const first = paragraph.children[index];
+        const separator = paragraph.children[index + 1];
+        const second = paragraph.children[index + 2];
+
+        if (!isLinkNode(first) || !isTextNode(separator) || !isLinkNode(second)) {
+          continue;
+        }
+
+        if (!/^\s*[—-]\s*$/.test(separator.value)) {
+          continue;
+        }
+
+        if (first.url !== second.url || !isReferenceOriginalLabel(toString(second))) {
+          continue;
+        }
+
+        paragraph.children.splice(index + 1, 2);
+        index -= 1;
+      }
+    });
+  }
+}
+
 export function transformMarkdownForExport(
   note: PublishedContentNote,
   index: ContentIndex,
@@ -310,6 +361,7 @@ export function transformMarkdownForExport(
 
   normalizeKatexMathTree(tree);
   transformReferenceSourceWikilinks(tree, index);
+  removeDuplicateReferenceOriginalLinks(tree);
 
   if (cover && isLocalAssetUrl(cover)) {
     try {

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -1,5 +1,5 @@
 import GithubSlugger from 'github-slugger';
-import type { Element, Root as HastRoot } from 'hast';
+import type { Element, Root as HastRoot, Text as HastText } from 'hast';
 import { toString as hastToString } from 'hast-util-to-string';
 import { ExternalLink } from 'lucide-react';
 import type { Heading, Root as MdastRoot } from 'mdast';
@@ -413,7 +413,67 @@ function markReferenceCardLists(node: Node) {
   );
 }
 
+function isHastElement(value: unknown): value is Element {
+  return Boolean(
+    value && typeof value === 'object' && (value as { type?: unknown }).type === 'element',
+  );
+}
+
+function isHastText(value: unknown): value is HastText {
+  return Boolean(
+    value && typeof value === 'object' && (value as { type?: unknown }).type === 'text',
+  );
+}
+
+function isReferenceOriginalLabel(value: string): boolean {
+  return /^(원문|original)$/i.test(value.trim());
+}
+
+function collapseDuplicateReferenceOriginalLinks(node: Node) {
+  visit(
+    node,
+    () => true,
+    current => {
+      if (!isHastElement(current)) {
+        return;
+      }
+
+      for (let index = 0; index < current.children.length - 2; index += 1) {
+        const first = current.children[index];
+        const separator = current.children[index + 1];
+        const second = current.children[index + 2];
+
+        if (!isHastElement(first) || !isHastText(separator) || !isHastElement(second)) {
+          continue;
+        }
+
+        if (first.tagName !== 'a' || second.tagName !== 'a') {
+          continue;
+        }
+
+        const firstHref = first.properties?.href;
+        const secondHref = second.properties?.href;
+        if (typeof firstHref !== 'string' || firstHref !== secondHref) {
+          continue;
+        }
+
+        if (
+          !/^\s*[—-]\s*$/.test(separator.value) ||
+          !isReferenceOriginalLabel(hastToString(second))
+        ) {
+          continue;
+        }
+
+        current.children.splice(index + 1, 2);
+        index -= 1;
+      }
+    },
+  );
+}
+
 function transformReferenceLinksToCards(node: Node) {
+  collapseDuplicateReferenceOriginalLinks(node);
+
   visit(
     node,
     () => true,

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
@@ -64,5 +64,5 @@ The table of contents should include this heading.
 
 # Sources
 
-- [[youtube-source]]
+- [[youtube-source]] — [원문](https://www.youtube.com/watch?v=fixture)
 - [[second-note]]


### PR DESCRIPTION
## Summary
- Collapse duplicate trailing 원문 links in reference sections when they point to the same source URL
- Add renderer-level defensive handling so direct markdown rendering also produces one compact bookmark
- Strengthen content quality and build smoke harnesses for the new reference spec

## Verification
- bun run verify