### PR TITLE
Render Markdown details and stabilize post metadata

### DIFF
--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -46,6 +46,32 @@ function readJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
 }
 
+function normalizeMachineDate(value: unknown): string {
+  if (!value) {
+    return '';
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return trimmed;
+  }
+
+  return date.toISOString();
+}
+
 function readExportedPosts(contentRoot: string) {
   if (!fs.existsSync(contentRoot)) {
     return [];
@@ -408,6 +434,27 @@ function checkPostMetadata(postFiles: string[], errors: string[], linkIndex: Con
     if (frontmatter.slug !== slug) {
       errors.push(
         `${relativeFile}: frontmatter slug "${String(frontmatter.slug)}" must match directory "${slug}".`,
+      );
+    }
+
+    const expectedPublishedAt = normalizeMachineDate(frontmatter.published_at ?? frontmatter.added);
+    const expectedUpdatedAt = normalizeMachineDate(
+      frontmatter.updated ?? frontmatter.published_at ?? frontmatter.added,
+    );
+
+    if (!post.publishedAt) {
+      errors.push(`${relativeFile}: postMeta must include publishedAt for SEO/RSS/sitemap.`);
+    } else if (expectedPublishedAt && post.publishedAt !== expectedPublishedAt) {
+      errors.push(
+        `${relativeFile}: postMeta publishedAt "${post.publishedAt}" must match frontmatter published_at/added "${expectedPublishedAt}".`,
+      );
+    }
+
+    if (!post.updatedAt) {
+      errors.push(`${relativeFile}: postMeta must include updatedAt for SEO/RSS/sitemap.`);
+    } else if (expectedUpdatedAt && post.updatedAt !== expectedUpdatedAt) {
+      errors.push(
+        `${relativeFile}: postMeta updatedAt "${post.updatedAt}" must match frontmatter updated/published_at/added "${expectedUpdatedAt}".`,
       );
     }
 

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -85,6 +85,7 @@ function detectMarkdownFeatures(markdown: string) {
     math: false,
     mermaid: false,
     code: false,
+    details: /<details\b/i.test(parsed.content) && /<summary\b/i.test(parsed.content),
     references:
       /^(#{1,6})\s+(?:\d+(?:\.\d+)*\.?\s*)?(참고문헌|references?|reference|sources?|source)\s*$/im.test(
         parsed.content,
@@ -144,6 +145,7 @@ function checkRenderedPost(post: PostMeta, errors: string[]) {
     [features.math, 'katex', 'KaTeX'],
     [features.mermaid, 'mermaid', 'Mermaid'],
     [features.code, 'data-rehype-pretty-code-figure', 'code highlight'],
+    [features.details, '<details', 'Markdown details'],
     [features.references, 'reference-card', 'compact reference card'],
     [features.image, 'markdown-image-trigger', 'markdown image lightbox trigger'],
   ] as const;
@@ -160,6 +162,10 @@ function checkRenderedPost(post: PostMeta, errors: string[]) {
 
   if (features.code && html.includes('data-theme="github-dark"')) {
     errors.push(`Post "${post.slug}" still renders dark-only code highlighting.`);
+  }
+
+  if (features.details && !html.includes('markdown-details-summary')) {
+    errors.push(`Post "${post.slug}" is missing rendered Markdown details summary styling.`);
   }
 
   if (post.cover && !html.includes('object-fill')) {
@@ -355,6 +361,16 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
 
   if (!/\.post-body \.markdown-alert p\{[^}]*margin:0[^}]*padding:0/.test(css)) {
     errors.push('Built Markdown CSS must reset callout paragraph margin and padding.');
+  }
+
+  if (
+    !/\.post-body \.markdown-details\{[^}]*background:var\(--bg-color-1\)/.test(css) ||
+    !/\.post-body \.markdown-details-summary\{[^}]*cursor:pointer/.test(css) ||
+    !/\.post-body \.markdown-details-content\{[^}]*border-top:\.0625rem solid var\(--fg-color-0\)/.test(
+      css,
+    )
+  ) {
+    errors.push('Built Markdown CSS must style collapsible details blocks.');
   }
 
   for (const alertType of ['note', 'tip', 'important', 'warning', 'caution']) {

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -218,6 +218,20 @@ function checkRenderedPost(post: PostMeta, errors: string[]) {
   if (features.references && html.includes('reference-card-title">원문')) {
     errors.push(`Post "${post.slug}" rendered duplicate 원문 reference bookmark cards.`);
   }
+
+  if (post.publishedAt && !html.includes(`"datePublished":"${post.publishedAt}"`)) {
+    errors.push(
+      `Post "${post.slug}" JSON-LD must use frontmatter published_at/added as datePublished.`,
+    );
+  }
+
+  if (post.updatedAt && !html.includes(`"dateModified":"${post.updatedAt}"`)) {
+    errors.push(`Post "${post.slug}" JSON-LD must use frontmatter updated as dateModified.`);
+  }
+
+  if (post.publishedAt && html.includes(`"datePublished":"${post.createdAt}"`)) {
+    errors.push(`Post "${post.slug}" JSON-LD must not use display createdAt as datePublished.`);
+  }
 }
 
 function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {

--- a/src/__tests__/libs/content/postMeta.test.ts
+++ b/src/__tests__/libs/content/postMeta.test.ts
@@ -54,6 +54,8 @@ describe('post metadata from exported content', () => {
       ),
     });
     expect(posts[0].createdAt).toBe('Jun 21, 2026');
+    expect(posts[0].publishedAt).toBe('2026-06-21');
+    expect(posts[0].updatedAt).toBe('2026-06-21');
     expect(posts[1]).toMatchObject({
       pageId: 'second-note',
       id: 1,

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -236,6 +236,28 @@ flowchart TD
     expect(container.querySelector('[onclick]')).not.toBeInTheDocument();
   });
 
+  it('renders markdown details blocks while still preserving markdown inside', async () => {
+    const content = await renderMarkdownToReact(`<details>
+<summary>IVFADC 인덱싱 의사코드 보기</summary>
+
+\`\`\`text
+Index_IVFADC(database)
+\`\`\`
+
+</details>
+`);
+
+    const { container } = render(<>{content}</>);
+    const details = container.querySelector('details.markdown-details');
+    const summary = screen.getByText('IVFADC 인덱싱 의사코드 보기');
+
+    expect(details).toBeInTheDocument();
+    expect(summary.tagName).toBe('SUMMARY');
+    expect(summary).toHaveClass('markdown-details-summary');
+    expect(container.querySelector('.markdown-details-content')).toBeInTheDocument();
+    expect(container.querySelector('pre code')).toHaveTextContent('Index_IVFADC');
+  });
+
   it('renders bold source wikilinks without leaking escaped emphasis markers', async () => {
     const content = await renderMarkdownToReact(
       'PostgreSQL 은 GitHub 가 아닌 **[[youtube-source|PostgreSQL 자체 Git 저장소]]**를 이용해야 합니다.',

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -258,6 +258,22 @@ Index_IVFADC(database)
     expect(container.querySelector('pre code')).toHaveTextContent('Index_IVFADC');
   });
 
+  it('does not render details summaries that contain raw HTML', async () => {
+    const content = await renderMarkdownToReact(`<details>
+<summary><script>alert(1)</script></summary>
+
+Unsafe summary body.
+
+</details>
+`);
+
+    const { container } = render(<>{content}</>);
+
+    expect(container.querySelector('details')).not.toBeInTheDocument();
+    expect(container.querySelector('script')).not.toBeInTheDocument();
+    expect(container).not.toHaveTextContent('alert(1)');
+  });
+
   it('renders bold source wikilinks without leaking escaped emphasis markers', async () => {
     const content = await renderMarkdownToReact(
       'PostgreSQL 은 GitHub 가 아닌 **[[youtube-source|PostgreSQL 자체 Git 저장소]]**를 이용해야 합니다.',

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -94,8 +94,8 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
       ogImage: post.cover || undefined,
       canonical: `/blog/${post.slug}`,
       keywords: post.tags,
-      publishedTime: post.createdAt,
-      modifiedTime: post.lastEditedAt,
+      publishedTime: post.publishedAt || post.createdAt,
+      modifiedTime: post.updatedAt || post.lastEditedAt,
       author: siteConfig.author.name,
     });
   } catch (error) {
@@ -130,8 +130,8 @@ export default async function PostPage({ params }: PostPageProps) {
     ogImage: post.cover || undefined,
     canonical: `/blog/${post.slug}`,
     keywords: post.tags,
-    publishedTime: post.createdAt,
-    modifiedTime: post.lastEditedAt,
+    publishedTime: post.publishedAt || post.createdAt,
+    modifiedTime: post.updatedAt || post.lastEditedAt,
     author: siteConfig.author.name,
   });
   const tableOfContents = extractTableOfContentsFromMarkdown(markdown);

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -27,7 +27,9 @@ export async function GET() {
   const items = posts
     .map(post => {
       const link = `${baseUrl}/blog/${post.slug}/`;
-      const pubDate = new Date(post.lastEditedAt || post.createdAt).toUTCString();
+      const pubDate = new Date(
+        post.updatedAt || post.publishedAt || post.lastEditedAt || post.createdAt,
+      ).toUTCString();
       const categories = post.tags.map(tag => `<category>${escapeXml(tag)}</category>`).join('');
       return [
         '    <item>',

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -42,7 +42,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getStaticPostList();
   const blogPosts: MetadataRoute.Sitemap = posts.map(post => ({
     url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: post.lastEditedAt ? new Date(post.lastEditedAt) : new Date(post.createdAt),
+    lastModified: new Date(
+      post.updatedAt || post.publishedAt || post.lastEditedAt || post.createdAt,
+    ),
     changeFrequency: 'weekly' as const,
     priority: 0.7,
   }));

--- a/src/components/sections/PostComments/PostComments.stories.tsx
+++ b/src/components/sections/PostComments/PostComments.stories.tsx
@@ -21,7 +21,7 @@ Giscus를 사용한 댓글 시스템 컴포넌트입니다.
 ## 사용법
 \`\`\`tsx
 <PostComments 
-  identifier="blog-post-slug"
+  term="blog-post-slug"
 />
 \`\`\`
         `,
@@ -29,9 +29,9 @@ Giscus를 사용한 댓글 시스템 컴포넌트입니다.
     },
   },
   argTypes: {
-    identifier: {
+    term: {
       control: 'text',
-      description: '댓글을 구분하기 위한 고유 식별자 (포스트 slug 등)',
+      description: '댓글을 구분하기 위한 안정적인 Giscus term. 블로그 글에서는 slug를 사용합니다.',
     },
     className: {
       control: 'text',
@@ -51,11 +51,11 @@ export const Default: Story = {
 };
 
 /**
- * 특정 식별자를 가진 댓글 섹션
+ * 특정 term을 가진 댓글 섹션
  */
-export const WithIdentifier: Story = {
+export const WithTerm: Story = {
   args: {
-    identifier: 12,
+    term: 'blog-post-slug',
   },
 };
 

--- a/src/components/sections/PostComments/PostComments.test.tsx
+++ b/src/components/sections/PostComments/PostComments.test.tsx
@@ -54,8 +54,8 @@ describe('PostComments', () => {
     expect(screen.getByLabelText('Comments-Section')).toBeInTheDocument();
   });
 
-  it('커스텀 식별자와 함께 렌더링된다', () => {
-    render(<PostComments identifier={123} />);
+  it('커스텀 term과 함께 렌더링된다', () => {
+    render(<PostComments term="post-slug" />);
 
     expect(screen.getByLabelText('Comments-Section')).toBeInTheDocument();
   });
@@ -255,11 +255,28 @@ describe('PostComments', () => {
     expect(giscusContainer).toHaveClass('w-full', 'min-h-[200px]');
   });
 
-  it('식별자가 있으면 specific mapping을 사용한다', () => {
-    const identifier = 123;
-    render(<PostComments identifier={identifier} />);
+  it('term이 없으면 pathname mapping을 사용한다', () => {
+    render(<PostComments />);
 
-    // Giscus 스크립트가 DOM에 추가되는지 확인
-    expect(screen.getByLabelText('Comments-Section')).toBeInTheDocument();
+    const script = screen
+      .getByLabelText('Comments-Section')
+      .querySelector('script[src="https://giscus.app/client.js"]');
+
+    expect(script).toHaveAttribute('data-mapping', 'pathname');
+    expect(script).not.toHaveAttribute('data-term');
+  });
+
+  it('slug term이 있으면 specific mapping을 사용한다', () => {
+    render(<PostComments term="product-quantization-for-nearest-neighbor-search-paper-review" />);
+
+    const script = screen
+      .getByLabelText('Comments-Section')
+      .querySelector('script[src="https://giscus.app/client.js"]');
+
+    expect(script).toHaveAttribute('data-mapping', 'specific');
+    expect(script).toHaveAttribute(
+      'data-term',
+      'product-quantization-for-nearest-neighbor-search-paper-review',
+    );
   });
 });

--- a/src/components/sections/PostComments/PostComments.tsx
+++ b/src/components/sections/PostComments/PostComments.tsx
@@ -9,8 +9,8 @@ import { useThemeStore } from '@/store/themeStore';
  * PostComments 컴포넌트 Props 인터페이스
  */
 export interface PostCommentsProps {
-  /** 댓글을 구분하기 위한 고유 식별자 (보통 ID) */
-  identifier?: number;
+  /** 댓글을 구분하기 위한 안정적인 Giscus term. 블로그 글에서는 slug를 사용합니다. */
+  term?: string;
   /** 추가적인 CSS 클래스명 */
   className?: string;
 }
@@ -27,10 +27,10 @@ export interface PostCommentsProps {
  * - 반응형 디자인
  * - 한국어 지원
  *
- * @param identifier - 댓글을 구분하기 위한 고유 식별자
+ * @param term - 댓글을 구분하기 위한 안정적인 Giscus term
  * @param className - 추가적인 CSS 클래스명
  */
-export function PostComments({ identifier, className = '' }: PostCommentsProps) {
+export function PostComments({ term, className = '' }: PostCommentsProps) {
   const commentsRef = useRef<HTMLDivElement>(null);
   const isGiscusLoadedRef = useRef(false);
   const { theme } = useThemeStore();
@@ -81,7 +81,7 @@ export function PostComments({ identifier, className = '' }: PostCommentsProps) 
       'data-repo-id': process.env.NEXT_PUBLIC_GISCUS_REPO_ID,
       'data-category': 'Comments',
       'data-category-id': process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID,
-      'data-mapping': identifier ? 'specific' : 'pathname',
+      'data-mapping': term ? 'specific' : 'pathname',
       'data-strict': '1',
       'data-reactions-enabled': '1',
       'data-emit-metadata': '0',
@@ -90,7 +90,7 @@ export function PostComments({ identifier, className = '' }: PostCommentsProps) 
       'data-lang': 'ko',
       crossorigin: 'anonymous',
       async: 'true',
-      ...(identifier && { 'data-term': String(identifier) }),
+      ...(term && { 'data-term': term }),
     };
 
     // Giscus 스크립트 생성 및 설정
@@ -104,7 +104,7 @@ export function PostComments({ identifier, className = '' }: PostCommentsProps) 
     commentsRef.current.appendChild(script);
     isGiscusLoadedRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identifier]); // theme는 초기 로드 시에만 필요하므로 의존성에서 제외
+  }, [term]); // theme는 초기 로드 시에만 필요하므로 의존성에서 제외
 
   // 테마 변경 시 Giscus에 메시지 전송 (스크립트 재로드 없이)
   useEffect(() => {

--- a/src/components/templates/PostTemplate/PostTemplate.test.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.test.tsx
@@ -147,18 +147,15 @@ vi.mock('@/components/sections/RelatedPosts', () => ({
 // Mock PostComments 컴포넌트
 vi.mock('@/components/sections/PostComments', () => ({
   PostComments: ({
-    identifier,
+    term,
     className,
     ...props
   }: {
-    identifier?: string;
+    term?: string;
     className?: string;
     [key: string]: unknown;
   }) => (
-    <div
-      data-testid="post-comments"
-      data-props={JSON.stringify({ identifier, className, ...props })}
-    >
+    <div data-testid="post-comments" data-props={JSON.stringify({ term, className, ...props })}>
       Comments Section
     </div>
   ),
@@ -257,13 +254,13 @@ describe('PostTemplate', () => {
       expect(props.nextPost.title).toBe('Next Post');
     });
 
-    it('PostComments에 올바른 props가 전달된다', () => {
+    it('PostComments에 slug term이 전달된다', () => {
       render(<PostTemplate {...defaultProps} />);
 
       const postComments = screen.getByTestId('post-comments');
       const props = JSON.parse(postComments.getAttribute('data-props') ?? '{}');
 
-      expect(props.identifier).toBe(1);
+      expect(props.term).toBe('test-post-title');
     });
   });
 

--- a/src/components/templates/PostTemplate/PostTemplate.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.tsx
@@ -173,7 +173,7 @@ export const PostTemplate = ({
 
         {/* Comments Section - 1024px 유지 */}
         <section className="mb-12 max-w-[1024px]">
-          <PostComments identifier={post.id} />
+          <PostComments term={post.slug} />
         </section>
       </main>
     </div>

--- a/src/libs/content/postMeta.ts
+++ b/src/libs/content/postMeta.ts
@@ -33,6 +33,25 @@ function formatContentDate(value: string | undefined): string {
   });
 }
 
+function normalizeMachineDate(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return trimmed;
+  }
+
+  return date.toISOString();
+}
+
 function removeMarkdownSyntax(value: string): string {
   return value
     .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
@@ -133,6 +152,8 @@ export function createPostMetaList(notes: KbNote[]): PostMeta[] {
     const date = getPostDate(note.frontmatter);
     const updated = note.frontmatter.updated || date;
     const categoryText = getPostCategoryText(note);
+    const publishedAt = normalizeMachineDate(date);
+    const updatedAt = normalizeMachineDate(updated);
 
     return {
       pageId: slug,
@@ -141,6 +162,8 @@ export function createPostMetaList(notes: KbNote[]): PostMeta[] {
       description: note.frontmatter.description || extractDescription(note.content),
       createdAt: formatContentDate(date),
       lastEditedAt: formatContentDate(updated),
+      publishedAt,
+      updatedAt,
       category: {
         text: categoryText,
         color: resolveCategoryColor(categoryText, note.frontmatter.category_color),

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -370,15 +370,6 @@ function remarkImageDimensions() {
   };
 }
 
-function decodeBasicHtmlEntities(value: string): string {
-  return value
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'");
-}
-
 function parseDetailsOpening(value: string): { summary: string; open: boolean } | null {
   const trimmed = value.trim();
 
@@ -391,7 +382,11 @@ function parseDetailsOpening(value: string): { summary: string; open: boolean } 
     return null;
   }
 
-  const summary = decodeBasicHtmlEntities(summaryMatch[1].replace(/<[^>]*>/g, '').trim());
+  const summary = summaryMatch[1].trim();
+  if (/[<>]/.test(summary)) {
+    return null;
+  }
+
   if (!summary) {
     return null;
   }

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -84,6 +84,20 @@ interface MdastTextNode {
   value: string;
 }
 
+interface MdastHtmlNode {
+  type: 'html';
+  value: string;
+}
+
+interface MdastHastNode {
+  type: string;
+  children?: unknown[];
+  data?: {
+    hName?: string;
+    hProperties?: Record<string, unknown>;
+  };
+}
+
 function isMdastImageNode(value: unknown): value is MdastImageNode {
   return Boolean(
     value && typeof value === 'object' && (value as { type?: unknown }).type === 'image',
@@ -99,6 +113,18 @@ function isMdastTextNode(value: unknown): value is MdastTextNode {
 function isMdastLinkNode(value: unknown): value is MdastLinkNode {
   return Boolean(
     value && typeof value === 'object' && (value as { type?: unknown }).type === 'link',
+  );
+}
+
+function isMdastHtmlNode(value: unknown): value is MdastHtmlNode {
+  return Boolean(
+    value && typeof value === 'object' && (value as { type?: unknown }).type === 'html',
+  );
+}
+
+function hasMdastChildren(value: unknown): value is MdastParent {
+  return Boolean(
+    value && typeof value === 'object' && Array.isArray((value as { children?: unknown }).children),
   );
 }
 
@@ -341,6 +367,119 @@ function remarkImageDimensions() {
         }
       }
     });
+  };
+}
+
+function decodeBasicHtmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function parseDetailsOpening(value: string): { summary: string; open: boolean } | null {
+  const trimmed = value.trim();
+
+  if (!/^<details(?:\s+open)?\s*>/i.test(trimmed)) {
+    return null;
+  }
+
+  const summaryMatch = trimmed.match(/<summary(?:\s[^>]*)?>([\s\S]*?)<\/summary>/i);
+  if (!summaryMatch) {
+    return null;
+  }
+
+  const summary = decodeBasicHtmlEntities(summaryMatch[1].replace(/<[^>]*>/g, '').trim());
+  if (!summary) {
+    return null;
+  }
+
+  return {
+    summary,
+    open: /^<details\s+open\s*>/i.test(trimmed),
+  };
+}
+
+function isDetailsClosing(value: unknown): value is MdastHtmlNode {
+  return isMdastHtmlNode(value) && /^<\/details>\s*$/i.test(value.value.trim());
+}
+
+function createDetailsNode(summary: string, children: unknown[], open: boolean): MdastHastNode {
+  return {
+    type: 'detailsBlock',
+    data: {
+      hName: 'details',
+      hProperties: {
+        className: ['markdown-details'],
+        ...(open ? { open: true } : {}),
+      },
+    },
+    children: [
+      {
+        type: 'detailsSummary',
+        data: {
+          hName: 'summary',
+          hProperties: {
+            className: ['markdown-details-summary'],
+          },
+        },
+        children: [{ type: 'text', value: summary }],
+      },
+      {
+        type: 'detailsContent',
+        data: {
+          hName: 'div',
+          hProperties: {
+            className: ['markdown-details-content'],
+          },
+        },
+        children,
+      },
+    ],
+  };
+}
+
+function transformDetailsBlocks(parent: MdastParent) {
+  for (let index = 0; index < parent.children.length; index += 1) {
+    const child = parent.children[index];
+
+    if (hasMdastChildren(child)) {
+      transformDetailsBlocks(child);
+    }
+
+    if (!isMdastHtmlNode(child)) {
+      continue;
+    }
+
+    const opening = parseDetailsOpening(child.value);
+    if (!opening) {
+      continue;
+    }
+
+    const closeIndex = parent.children.findIndex(
+      (candidate, candidateIndex) => candidateIndex > index && isDetailsClosing(candidate),
+    );
+    if (closeIndex === -1) {
+      continue;
+    }
+
+    const detailsChildren = parent.children.slice(index + 1, closeIndex);
+    transformDetailsBlocks({ children: detailsChildren });
+    parent.children.splice(
+      index,
+      closeIndex - index + 1,
+      createDetailsNode(opening.summary, detailsChildren, opening.open),
+    );
+  }
+}
+
+function remarkDetailsBlocks() {
+  return function transformer(tree: Node) {
+    if (hasMdastChildren(tree)) {
+      transformDetailsBlocks(tree);
+    }
   };
 }
 
@@ -678,6 +817,7 @@ export async function renderMarkdownToReact(
     .use(remarkResolveWikiLinks(linkMaps))
     .use(remarkRepairAdjacentStrongMarkers)
     .use(remarkAlert)
+    .use(remarkDetailsBlocks)
     .use(remarkRehype)
     .use(rehypeMermaidComponent)
     .use(rehypeKatex)

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -211,6 +211,47 @@
   font-style: normal;
 }
 
+.post-body .markdown-details {
+  display: block;
+  width: 100%;
+  margin: 0.6rem 0;
+  padding: 0.35rem 0.55rem;
+  border: 0.0625rem solid var(--fg-color-0);
+  border-radius: 0.5rem;
+  background: var(--bg-color-1);
+}
+
+.post-body .markdown-details-summary {
+  display: list-item;
+  padding: 0.35rem 0.2rem;
+  color: var(--fg-color);
+  font-weight: 600;
+  line-height: 1.5;
+  cursor: pointer;
+}
+
+.post-body .markdown-details-summary::marker {
+  color: var(--fg-color-3);
+}
+
+.post-body .markdown-details-summary:hover {
+  color: var(--fg-color-6);
+}
+
+.post-body .markdown-details-content {
+  margin-top: 0.3rem;
+  padding-top: 0.45rem;
+  border-top: 0.0625rem solid var(--fg-color-0);
+}
+
+.post-body .markdown-details-content > *:first-child {
+  margin-top: 0;
+}
+
+.post-body .markdown-details-content > *:last-child {
+  margin-bottom: 0;
+}
+
 .post-body ul,
 .post-body ol {
   width: 100%;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -27,6 +27,14 @@ export interface PostMeta {
    */
   lastEditedAt?: string;
   /**
+   * 최초 발행일. SEO/RSS/sitemap에서 사용하는 ISO 8601 날짜입니다.
+   */
+  publishedAt?: string;
+  /**
+   * 마지막 수정일. SEO/RSS/sitemap에서 사용하는 ISO 8601 날짜입니다.
+   */
+  updatedAt?: string;
+  /**
    * 카테고리 정보
    */
   category: {

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
@@ -62,6 +62,15 @@ export const answer = 42;
 
 The table of contents should include this heading.
 
+<details>
+<summary>Fixture details 보기</summary>
+
+```text
+details body
+```
+
+</details>
+
 # Sources
 
 - [[youtube-source]] — [원문](https://www.youtube.com/watch?v=fixture)


### PR DESCRIPTION
## Summary
- Render safe Markdown details/summary blocks without enabling arbitrary raw HTML
- Use post slug as the stable Giscus specific term instead of generated numeric post IDs
- Preserve KB frontmatter dates as machine-readable publishedAt/updatedAt for SEO, RSS, sitemap, and JSON-LD
- Strengthen content quality and build smoke checks for details rendering and SEO dates

## Verification
- bun run verify