### PR TITLE
Add overflow scroll to table of contents

### DIFF
--- a/src/components/ui/blog/TableOfContents/TableOfContents.test.tsx
+++ b/src/components/ui/blog/TableOfContents/TableOfContents.test.tsx
@@ -72,6 +72,16 @@ describe('TableOfContents', () => {
     expect(screen.getByText('ABCD is Bad?')).toBeInTheDocument();
   });
 
+  it('긴 목차에서 y축 스크롤이 가능하도록 높이를 제한한다', () => {
+    render(<TableOfContents items={mockItems} />);
+
+    const container = screen.getByText('Contents').closest('aside');
+
+    expect(container).toHaveClass('max-h-[calc(100vh-7rem)]');
+    expect(container).toHaveClass('overflow-y-auto');
+    expect(container).toHaveClass('overscroll-contain');
+  });
+
   it('활성화된 항목을 하이라이트한다', () => {
     render(<TableOfContents items={mockItems} activeId="section-1" />);
 

--- a/src/components/ui/blog/TableOfContents/TableOfContents.tsx
+++ b/src/components/ui/blog/TableOfContents/TableOfContents.tsx
@@ -86,6 +86,7 @@ export function TableOfContents({
       className={`
         w-full xl:w-[16rem]
         xl:pl-4 py-4
+        max-h-[calc(100vh-7rem)] overflow-y-auto overscroll-contain pr-2
         ${className}
       `}
     >


### PR DESCRIPTION
## Summary
- Limit the ToC container height relative to the viewport
- Enable vertical scrolling for long table-of-contents lists
- Add a unit test for ToC overflow behavior

## Verification
- bun run verify