### PR TITLE
Harden generated content hygiene

### DIFF
--- a/.agents/r3gardless-dev/SKILL.md
+++ b/.agents/r3gardless-dev/SKILL.md
@@ -15,11 +15,12 @@ This file is the shared skill source for AI coding agents. Tool-specific entrypo
 
 1. Inspect existing files before making assumptions.
 2. Preserve static export and GitHub Pages constraints.
-3. Treat the KNOWLEDGE_BASE source as read-only. Only generated `content/posts`, `public/content`, and `public/data` are written by scripts.
+3. Treat the KNOWLEDGE_BASE source as read-only. Only generated `content/posts`, `public/content`, and `public/data` are written by scripts, and those generated outputs must stay untracked.
 4. Use `cover` as the only canonical image frontmatter field, and keep exported cover/body asset URLs content hash based for cache busting.
 5. Keep blog body typography Pretendard; reserve MaruBuri for logo, hero/page titles, and section headings.
 6. Keep Markdown body styles in `src/styles/markdown.css` under `.post-body`; do not recreate the legacy Notion stylesheet.
-7. Run the narrow relevant tests first, then `bun run verify` before finishing substantial work.
+7. Keep default build and sync logs free of private KNOWLEDGE_BASE absolute paths or internal directory structure. Use `CONTENT_VERBOSE_LOGS=1` only for local debugging.
+8. Run the narrow relevant tests first, then `bun run verify` before finishing substantial work.
 
 ## Critical Gates
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,14 +5,15 @@ This repository is a Next.js static blog that renders Markdown exported from a p
 ## Core Rules
 
 - Use Bun for package and script execution.
-- The source KB is read-only. Only generated `content/posts/`, `public/content/`, and `public/data/` are written by the site pipeline.
+- The source KNOWLEDGE_BASE is read-only. Only generated `content/posts/`, `public/content/`, and `public/data/` are written by the site pipeline, and those generated outputs must stay untracked.
 - Publish only Markdown with frontmatter `publish: true`; never publish raw/source notes.
 - Keep static export working for GitHub Pages.
 - Do not add auto-merge workflows.
+- Keep default build and sync logs free of private KNOWLEDGE_BASE absolute paths or internal directory structure. Use `CONTENT_VERBOSE_LOGS=1` only for local debugging.
 
 ## Content Pipeline
 
-- `KB_PATH` points to the KB root. CI checks out the private KB into `.cache/knowledge-base`.
+- `KNOWLEDGE_BASE_PATH` points to the KNOWLEDGE_BASE root. CI checks out the private repository into `.cache/knowledge-base`.
 - `bun run build:content` exports publishable notes and referenced assets.
 - `bun run build:meta` writes `public/data/postMeta.json`.
 - `bun run check-links` fails leftover `.md` links, missing images, and broken publish links.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ r3gardless.dev/
 
 KNOWLEDGE_BASE 원본은 읽기 전용입니다. 이 레포의 파이프라인은 generated output만 쓰며, KNOWLEDGE_BASE 파일을 수정하지 않습니다. 예외는 마이그레이션 회고 노트 1건 추가가 명시된 작업뿐입니다.
 
+`content/posts/`, `public/content/`, `public/data/`는 빌드 산출물입니다. git에 저장하지 말고, `bun run check-repo`가 이 경로의 `.gitignore`와 추적 여부를 검증해야 합니다. 기본 빌드/동기화 로그는 private KNOWLEDGE_BASE의 절대경로나 내부 디렉터리 구조를 출력하지 않습니다. 로컬 디버깅에 상세 경로가 필요할 때만 `CONTENT_VERBOSE_LOGS=1`을 사용합니다.
+
 ## 명령어
 
 ```bash

--- a/docs/REPO_GUIDE.md
+++ b/docs/REPO_GUIDE.md
@@ -40,6 +40,8 @@ r3gardless.dev/
 - `category`는 frontmatter 값을 우선합니다. 없을 때만 `.../<category>/wiki/...` 경로에서 파생합니다. `type: concept` 같은 KNOWLEDGE_BASE 타입을 블로그 category로 쓰지 않습니다.
 - KNOWLEDGE_BASE 내부 `.md` 링크와 wikilink는 발행 글이면 `/blog/<slug>`, source 노트면 `source_url`/`archived_url`, 그 외에는 텍스트 강등입니다.
 - raw/source 원문은 절대 `content/posts/`로 export하지 않습니다.
+- `content/posts/`, `public/content/`, `public/data/`는 generated output이며 git에 저장하지 않습니다. `bun run check-repo`는 이 경로가 `.gitignore`에 있고 실제 추적되지 않는지 확인합니다.
+- 빌드/동기화 로그는 기본적으로 private KNOWLEDGE_BASE의 절대경로나 내부 디렉터리 구조를 출력하지 않습니다. 상세 경로가 필요한 로컬 디버깅은 `CONTENT_VERBOSE_LOGS=1`로만 켭니다.
 
 ## 디자인 톤앤매너
 

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -17,13 +17,14 @@ import {
 
 const PUBLIC_ASSETS_BASE_PATH = 'content/posts';
 const LINK_INDEX_PATH = path.join(PROJECT_ROOT, 'public', 'data', 'contentLinkIndex.json');
+const VERBOSE_LOGS = process.env.CONTENT_VERBOSE_LOGS === '1';
 
 function assertProjectSubpath(dirPath: string) {
   const resolvedPath = path.resolve(dirPath);
   const relativePath = path.relative(PROJECT_ROOT, resolvedPath);
 
   if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-    throw new Error(`Refusing to reset directory outside project root: ${resolvedPath}`);
+    throw new Error('Refusing to reset directory outside project root.');
   }
 }
 
@@ -36,8 +37,9 @@ function resetDirectory(dirPath: string) {
 function reportDiagnostics(diagnostics: ContentDiagnostic[]) {
   for (const diagnostic of diagnostics) {
     const prefix = diagnostic.level === 'error' ? 'ERROR' : 'WARN';
+    const file = VERBOSE_LOGS && diagnostic.file ? ` ${diagnostic.file}` : '';
     console[diagnostic.level === 'error' ? 'error' : 'warn'](
-      `[${prefix}] ${diagnostic.code}${diagnostic.file ? ` ${diagnostic.file}` : ''}: ${diagnostic.message}`,
+      `[${prefix}] ${diagnostic.code}${file}: ${diagnostic.message}`,
     );
   }
 }
@@ -77,7 +79,7 @@ function main() {
     process.exit(1);
   }
 
-  console.log(`Exported ${index.publishedNotes.length} posts from ${kbRoot}`);
+  console.log(`Exported ${index.publishedNotes.length} published posts.`);
 }
 
 main();

--- a/scripts/build-post-meta.ts
+++ b/scripts/build-post-meta.ts
@@ -31,12 +31,13 @@ async function main() {
       .then(() => true)
       .catch(() => false);
     if (!fileExists) {
-      throw new Error(`Failed to create postMeta.json file at ${outputPath}`);
+      throw new Error('Failed to create postMeta.json file.');
     }
 
-    console.log(`Generated ${posts.length} post metadata records from ${contentRoot}`);
+    console.log(`Generated ${posts.length} post metadata records.`);
   } catch (error) {
-    console.error('Build metadata process failed:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Build metadata process failed: ${message}`);
     process.exit(1);
   }
 }

--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -32,6 +32,7 @@ const RELATIVE_MARKDOWN_LINK_PATTERN = /\.mdx?(#.*)?$/i;
 const LOCAL_ASSET_PATTERN = /^(\.{1,2}\/|assets\/)/i;
 const PUBLIC_CONTENT_ASSET_PATTERN = /^\/content\/posts\/[^/]+\/assets\/[^?#]+$/;
 const CONTENT_HASHED_ASSET_PATTERN = /\.[a-f0-9]{12}\.[^/.?#]+$/i;
+const VERBOSE_LOGS = process.env.CONTENT_VERBOSE_LOGS === '1';
 
 interface MathNode {
   type: 'math' | 'inlineMath';
@@ -271,7 +272,7 @@ function checkSourceFrontmatter(errors: string[]) {
       continue;
     }
 
-    const relativeFile = path.relative(kbRoot, filePath);
+    const relativeFile = VERBOSE_LOGS ? path.relative(kbRoot, filePath) : path.basename(filePath);
     errors.push(
       `${relativeFile}: published KNOWLEDGE_BASE frontmatter must use cover, not thumbnail.`,
     );

--- a/scripts/check-repo-governance.ts
+++ b/scripts/check-repo-governance.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -63,6 +64,40 @@ const REQUIRED_FILES = [
   '.husky/pre-push',
   '.github/workflows/ci.yml',
   '.github/workflows/deploy.yml',
+];
+
+const GENERATED_ARTIFACT_PATTERNS = ['content/posts/', 'public/content/', 'public/data/'];
+
+const PRIVATE_LOG_HYGIENE_PATTERNS = [
+  {
+    file: 'scripts/build-content.ts',
+    forbidden: ['from ${kbRoot}', '${diagnostic.file ?'],
+  },
+  {
+    file: 'scripts/build-post-meta.ts',
+    forbidden: [
+      'from ${contentRoot}',
+      'at ${outputPath}',
+      "console.error('Build metadata process failed:', error)",
+    ],
+  },
+  {
+    file: 'scripts/content-paths.ts',
+    forbidden: ['Tried: ${KNOWLEDGE_BASE_PATH_CANDIDATES'],
+  },
+  {
+    file: 'scripts/sync-knowledge-base.ts',
+    forbidden: [
+      "stdio: 'inherit'",
+      'already exists: ${path.resolve(configuredPath)}',
+      'to ${resolveSyncedKbPath()}',
+      'does not look like a KNOWLEDGE_BASE: ${SYNC_ROOT}',
+    ],
+  },
+  {
+    file: 'src/libs/content/scanner.ts',
+    forbidden: ['does not exist: ${kbRoot}', 'also used by ${duplicate.relativePath}'],
+  },
 ];
 
 interface PackageJson {
@@ -141,6 +176,45 @@ function checkRequiredFiles(errors: string[]) {
     errors.push(
       '.codex/skills/r3gardless-dev/references/repo-guide.md must symlink to shared .agents reference.',
     );
+  }
+}
+
+function checkGeneratedArtifactsIgnored(errors: string[]) {
+  const gitignore = readText('.gitignore');
+
+  for (const pattern of GENERATED_ARTIFACT_PATTERNS) {
+    if (!gitignore.includes(pattern)) {
+      errors.push(`.gitignore must ignore generated build artifact path: ${pattern}`);
+    }
+  }
+
+  const trackedArtifacts = execFileSync(
+    'git',
+    ['ls-files', 'content/posts', 'public/content', 'public/data'],
+    {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    },
+  )
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+  if (trackedArtifacts.length > 0) {
+    errors.push(
+      `Generated content artifacts must not be tracked in git: ${trackedArtifacts.join(', ')}`,
+    );
+  }
+}
+
+function checkPrivateLogHygiene(errors: string[]) {
+  for (const { file, forbidden } of PRIVATE_LOG_HYGIENE_PATTERNS) {
+    const text = readText(file);
+    for (const snippet of forbidden) {
+      if (text.includes(snippet)) {
+        errors.push(`${file}: build logs must not expose private content paths by default.`);
+      }
+    }
   }
 }
 
@@ -449,6 +523,8 @@ function main() {
   const errors: string[] = [];
 
   checkRequiredFiles(errors);
+  checkGeneratedArtifactsIgnored(errors);
+  checkPrivateLogHygiene(errors);
   checkPackageScripts(errors);
   checkWorkflows(errors);
   checkKbPathResolution(errors);

--- a/scripts/content-paths.ts
+++ b/scripts/content-paths.ts
@@ -34,7 +34,7 @@ export function resolveKbPath(): string {
   }
 
   throw new Error(
-    `KNOWLEDGE_BASE_PATH is required. Tried: ${KNOWLEDGE_BASE_PATH_CANDIDATES.map(candidate => `"${candidate}"`).join(', ')}`,
+    'KNOWLEDGE_BASE_PATH is required. Set it to the private content repository root or run bun run sync:knowledge-base.',
   );
 }
 

--- a/scripts/sync-knowledge-base.ts
+++ b/scripts/sync-knowledge-base.ts
@@ -6,14 +6,26 @@ import path from 'node:path';
 import { PROJECT_ROOT } from './content-paths.js';
 
 const DEFAULT_KNOWLEDGE_BASE_REPO_URL = 'https://github.com/R3gardless/KNOWLEDGE_BASE.git';
+const VERBOSE_LOGS = process.env.CONTENT_VERBOSE_LOGS === '1';
 const SYNC_ROOT = path.resolve(
   process.env.KNOWLEDGE_BASE_SYNC_DIR ||
     process.env.KB_SYNC_DIR ||
     path.join(PROJECT_ROOT, '.cache', 'knowledge-base'),
 );
 
-function runGit(args: string[]) {
-  execFileSync('git', args, { stdio: 'inherit' });
+function runGit(args: string[], failureMessage = 'Private content repository sync failed.') {
+  try {
+    const output = execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    if (VERBOSE_LOGS && output) {
+      process.stdout.write(output);
+    }
+  } catch {
+    throw new Error(failureMessage);
+  }
 }
 
 function hasMarkdownRoot(dirPath: string): boolean {
@@ -33,7 +45,7 @@ function resolveSyncedKbPath(): string {
 
   const found = candidates.find(hasMarkdownRoot);
   if (!found) {
-    throw new Error(`Synced repository does not look like a KNOWLEDGE_BASE: ${SYNC_ROOT}`);
+    throw new Error('Synced private content repository is missing a Markdown root.');
   }
 
   return found;
@@ -42,7 +54,7 @@ function resolveSyncedKbPath(): string {
 function main() {
   const configuredPath = process.env.KNOWLEDGE_BASE_PATH || process.env.KB_PATH;
   if (configuredPath && fs.existsSync(configuredPath)) {
-    console.log(`KNOWLEDGE_BASE_PATH already exists: ${path.resolve(configuredPath)}`);
+    console.log('Private content repository already available.');
     return;
   }
 
@@ -53,13 +65,26 @@ function main() {
   fs.mkdirSync(path.dirname(SYNC_ROOT), { recursive: true });
 
   if (fs.existsSync(path.join(SYNC_ROOT, '.git'))) {
-    runGit(['-C', SYNC_ROOT, 'pull', '--ff-only']);
+    try {
+      runGit(['-C', SYNC_ROOT, 'pull', '--quiet', '--ff-only']);
+    } catch (error) {
+      if (process.env.CI === 'true') {
+        throw error;
+      }
+
+      resolveSyncedKbPath();
+      console.warn(
+        'Private content repository update failed; using the existing local cache. Set CONTENT_VERBOSE_LOGS=1 and retry sync for local debugging.',
+      );
+      return;
+    }
   } else {
     fs.rmSync(SYNC_ROOT, { recursive: true, force: true });
-    runGit(['clone', '--depth=1', repoUrl, SYNC_ROOT]);
+    runGit(['clone', '--quiet', '--depth=1', repoUrl, SYNC_ROOT]);
   }
 
-  console.log(`Synced KNOWLEDGE_BASE to ${resolveSyncedKbPath()}`);
+  resolveSyncedKbPath();
+  console.log('Private content repository synced.');
 }
 
 main();

--- a/src/libs/content/scanner.ts
+++ b/src/libs/content/scanner.ts
@@ -54,7 +54,7 @@ function createPublishedNote(note: KbNote): PublishedContentNote {
 
 export function scanKbNotes(kbRoot: string): KbNote[] {
   if (!fs.existsSync(kbRoot)) {
-    throw new Error(`KNOWLEDGE_BASE_PATH does not exist: ${kbRoot}`);
+    throw new Error('KNOWLEDGE_BASE_PATH does not exist.');
   }
 
   return walkMarkdownFiles(kbRoot).map(filePath => parseKbMarkdownFile(filePath, kbRoot));
@@ -112,7 +112,7 @@ export function buildContentIndex(kbRoot: string): ContentIndex {
       diagnostics.push({
         level: 'error',
         code: 'DUPLICATE_SLUG',
-        message: `Duplicate published slug "${published.slug}" also used by ${duplicate.relativePath}.`,
+        message: `Duplicate published slug "${published.slug}" is used by more than one published note.`,
         file: note.relativePath,
       });
     }


### PR DESCRIPTION
## Summary
- hide private KNOWLEDGE_BASE paths from default content build/sync logs
- enforce generated content outputs stay ignored and untracked
- document generated-output and log-hygiene rules for shared agents

## Verification
- KNOWLEDGE_BASE_PATH=.cache/knowledge-base bun run verify
- pre-push next build