### PR TITLE
Improve blog search matching

### DIFF
--- a/src/__tests__/utils/search.test.ts
+++ b/src/__tests__/utils/search.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PostMeta } from '@/types/blog';
+import { filterPostsBySearch, matchesPostSearch } from '@/utils/search';
+
+const createPost = (overrides: Partial<PostMeta>): PostMeta => ({
+  pageId: 'post',
+  id: 1,
+  title: 'Product Quantization for Nearest Neighbor Search',
+  description: 'Codebook compression keeps vector distance search small enough for memory.',
+  createdAt: 'Jun 21, 2026',
+  category: {
+    text: 'Vector Search',
+    color: 'purple',
+  },
+  tags: ['Paper Review', 'Vector Database'],
+  slug: 'product-quantization',
+  encodedSlug: 'product-quantization',
+  ...overrides,
+});
+
+describe('search utils', () => {
+  it('description을 검색 범위에 포함한다', () => {
+    const post = createPost({
+      title: 'Unrelated Title',
+      description: 'Approximate nearest neighbor index를 설명합니다.',
+    });
+
+    expect(matchesPostSearch(post, 'nearest neighbor')).toBe(true);
+  });
+
+  it('제목의 오타를 fuzzy search로 매칭한다', () => {
+    const post = createPost({});
+
+    expect(matchesPostSearch(post, 'product quantizaton')).toBe(true);
+    expect(matchesPostSearch(post, 'neareset')).toBe(true);
+  });
+
+  it('description의 오타를 fuzzy search로 매칭한다', () => {
+    const post = createPost({
+      title: 'Unrelated Title',
+      description: 'Large codebook memory pressure and vector compression tradeoffs.',
+    });
+
+    expect(matchesPostSearch(post, 'codebok')).toBe(true);
+  });
+
+  it('여러 검색어를 title, description, tag 범위에 걸쳐 모두 만족해야 매칭한다', () => {
+    const post = createPost({
+      title: 'PostgreSQL Source Debugging',
+      description: 'VSCode launch configuration으로 디버깅 환경을 잡습니다.',
+      tags: ['Database'],
+    });
+
+    expect(matchesPostSearch(post, 'postgresql launch database')).toBe(true);
+    expect(matchesPostSearch(post, 'postgresql mermaid')).toBe(false);
+  });
+
+  it('기존 category와 tag 검색 의도를 유지한다', () => {
+    const post = createPost({
+      title: 'Unrelated Title',
+      description: 'No keyword here.',
+      category: { text: 'Build System', color: 'blue' },
+      tags: ['Makefile'],
+    });
+
+    expect(matchesPostSearch(post, 'build system')).toBe(true);
+    expect(matchesPostSearch(post, 'makefile')).toBe(true);
+  });
+
+  it('포스트 배열을 검색 결과로 필터링한다', () => {
+    const posts = [
+      createPost({ id: 1, slug: 'pq' }),
+      createPost({
+        id: 2,
+        slug: 'browser-sync',
+        title: 'Browser File Sync',
+        description: 'File System Access API를 이용한 동기화.',
+        tags: ['Browser'],
+      }),
+    ];
+
+    expect(filterPostsBySearch(posts, 'file system access')).toEqual([posts[1]]);
+    expect(filterPostsBySearch(posts, '')).toEqual(posts);
+  });
+});

--- a/src/app/blog/BlogPageClient.test.tsx
+++ b/src/app/blog/BlogPageClient.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PostMeta } from '@/types/blog';
+
+import BlogPageClient from './BlogPageClient';
+
+const navigationMocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  searchParams: new URLSearchParams(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: navigationMocks.replace,
+  }),
+  useSearchParams: () => navigationMocks.searchParams,
+}));
+
+vi.mock('@/components/templates/BlogTemplate', () => ({
+  BlogTemplate: ({
+    header,
+    posts,
+  }: {
+    header: {
+      searchValue: string;
+      onSearchChange?: (value: string) => void;
+      onSearch?: (value: string) => void;
+    };
+    posts: {
+      posts: Array<{ slug: string; title: string }>;
+      emptyMessage?: string;
+    };
+  }) => (
+    <section>
+      <input
+        aria-label="search"
+        value={header.searchValue}
+        onChange={event => header.onSearchChange?.(event.currentTarget.value)}
+      />
+      <button type="button" onClick={() => header.onSearch?.(header.searchValue)}>
+        Search
+      </button>
+      <div data-testid="post-count">{posts.posts.length}</div>
+      {posts.posts.map(post => (
+        <article key={post.slug}>{post.title}</article>
+      ))}
+      {posts.emptyMessage ? <p>{posts.emptyMessage}</p> : null}
+    </section>
+  ),
+}));
+
+const createPost = (overrides: Partial<PostMeta>): PostMeta => ({
+  pageId: 'post',
+  id: 1,
+  title: 'Product Quantization for Nearest Neighbor Search',
+  description: 'Codebook compression for vector search.',
+  createdAt: 'Jun 21, 2026',
+  category: {
+    text: 'Vector Search',
+    color: 'purple',
+  },
+  tags: ['Paper Review'],
+  slug: 'product-quantization',
+  encodedSlug: 'product-quantization',
+  ...overrides,
+});
+
+describe('BlogPageClient search filtering', () => {
+  const posts = [
+    createPost({ id: 1, slug: 'product-quantization' }),
+    createPost({
+      id: 2,
+      slug: 'browser-file-sync',
+      title: 'Browser File Sync',
+      description: 'File System Access API로 브라우저에서 파일을 동기화합니다.',
+      category: {
+        text: 'Frontend',
+        color: 'blue',
+      },
+      tags: ['Browser'],
+    }),
+  ];
+
+  beforeEach(() => {
+    navigationMocks.replace.mockClear();
+    navigationMocks.searchParams = new URLSearchParams();
+  });
+
+  it('title에 없는 description 검색어로 포스트를 필터링한다', async () => {
+    const user = userEvent.setup();
+    render(<BlogPageClient initialPosts={posts} initialCategories={[]} initialTags={[]} />);
+
+    await waitFor(() => expect(screen.getByTestId('post-count')).toHaveTextContent('2'));
+    await user.type(screen.getByLabelText('search'), 'file system access');
+
+    expect(screen.getByText('Browser File Sync')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Product Quantization for Nearest Neighbor Search'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('오타가 있는 검색어를 fuzzy search로 필터링한다', async () => {
+    const user = userEvent.setup();
+    render(<BlogPageClient initialPosts={posts} initialCategories={[]} initialTags={[]} />);
+
+    await waitFor(() => expect(screen.getByTestId('post-count')).toHaveTextContent('2'));
+    await user.type(screen.getByLabelText('search'), 'quantizaton');
+
+    expect(
+      screen.getByText('Product Quantization for Nearest Neighbor Search'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Browser File Sync')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/blog/BlogPageClient.test.tsx
+++ b/src/app/blog/BlogPageClient.test.tsx
@@ -93,7 +93,11 @@ describe('BlogPageClient search filtering', () => {
     render(<BlogPageClient initialPosts={posts} initialCategories={[]} initialTags={[]} />);
 
     await waitFor(() => expect(screen.getByTestId('post-count')).toHaveTextContent('2'));
-    await user.type(screen.getByLabelText('search'), 'file system access');
+    const input = screen.getByLabelText('search');
+    await waitFor(() => expect(input).toHaveValue(''));
+
+    await user.type(input, 'file system access');
+    await waitFor(() => expect(input).toHaveValue('file system access'));
 
     expect(screen.getByText('Browser File Sync')).toBeInTheDocument();
     expect(
@@ -106,7 +110,11 @@ describe('BlogPageClient search filtering', () => {
     render(<BlogPageClient initialPosts={posts} initialCategories={[]} initialTags={[]} />);
 
     await waitFor(() => expect(screen.getByTestId('post-count')).toHaveTextContent('2'));
-    await user.type(screen.getByLabelText('search'), 'quantizaton');
+    const input = screen.getByLabelText('search');
+    await waitFor(() => expect(input).toHaveValue(''));
+
+    await user.type(input, 'quantizaton');
+    await waitFor(() => expect(input).toHaveValue('quantizaton'));
 
     expect(
       screen.getByText('Product Quantization for Nearest Neighbor Search'),

--- a/src/app/blog/BlogPageClient.tsx
+++ b/src/app/blog/BlogPageClient.tsx
@@ -7,6 +7,7 @@ import { BlogTemplate } from '@/components/templates/BlogTemplate';
 import type { PostRowProps } from '@/components/ui/blog/PostRow';
 import type { PostMeta } from '@/types/blog';
 import { convertPostsForRendering } from '@/utils/blog';
+import { filterPostsBySearch } from '@/utils/search';
 
 interface BlogPageClientProps {
   initialPosts: PostMeta[];
@@ -53,14 +54,7 @@ function BlogPageContent({ initialPosts, initialCategories, initialTags }: BlogP
 
     // 검색 필터링
     if (searchValue.trim()) {
-      const query = searchValue.toLowerCase().trim();
-      filtered = filtered.filter(
-        post =>
-          post.title.toLowerCase().includes(query) ??
-          (post.description && post.description.toLowerCase().includes(query)) ??
-          post.category.text.toLowerCase().includes(query) ??
-          post.tags.some(tag => tag.toLowerCase().includes(query)),
-      );
+      filtered = filterPostsBySearch(filtered, searchValue);
     }
 
     // 카테고리 필터링

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -11,10 +11,9 @@ export function matchesPostSearch(post: PostMeta, rawQuery: string): boolean {
 
   const fields = getPostSearchFields(post);
   const normalizedFields = fields.map(normalizeSearchText).filter(Boolean);
-  const combinedText = normalizedFields.join(' ');
   const phrase = queryTokens.join(' ');
 
-  if (combinedText.includes(phrase)) {
+  if (normalizedFields.some(field => field.includes(phrase))) {
     return true;
   }
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,114 @@
+import type { PostMeta } from '@/types/blog';
+
+const MIN_FUZZY_TOKEN_LENGTH = 4;
+
+export function matchesPostSearch(post: PostMeta, rawQuery: string): boolean {
+  const queryTokens = tokenizeSearchText(rawQuery);
+
+  if (queryTokens.length === 0) {
+    return true;
+  }
+
+  const fields = getPostSearchFields(post);
+  const normalizedFields = fields.map(normalizeSearchText).filter(Boolean);
+  const combinedText = normalizedFields.join(' ');
+  const phrase = queryTokens.join(' ');
+
+  if (combinedText.includes(phrase)) {
+    return true;
+  }
+
+  return queryTokens.every(token =>
+    normalizedFields.some(field => matchesSearchToken(token, field)),
+  );
+}
+
+export function filterPostsBySearch(posts: PostMeta[], rawQuery: string): PostMeta[] {
+  const query = rawQuery.trim();
+
+  if (!query) {
+    return posts;
+  }
+
+  return posts.filter(post => matchesPostSearch(post, query));
+}
+
+function getPostSearchFields(post: PostMeta): string[] {
+  return [post.title, post.description ?? '', post.category.text, ...post.tags];
+}
+
+function matchesSearchToken(token: string, normalizedField: string): boolean {
+  if (normalizedField.includes(token)) {
+    return true;
+  }
+
+  if (token.length < MIN_FUZZY_TOKEN_LENGTH) {
+    return false;
+  }
+
+  return normalizedField.split(' ').some(candidate => isFuzzyTokenMatch(token, candidate));
+}
+
+function isFuzzyTokenMatch(queryToken: string, candidate: string): boolean {
+  if (candidate.length < MIN_FUZZY_TOKEN_LENGTH) {
+    return false;
+  }
+
+  const maxLength = Math.max(queryToken.length, candidate.length);
+  const maxDistance = maxAllowedDistance(maxLength);
+
+  if (Math.abs(queryToken.length - candidate.length) > maxDistance) {
+    return false;
+  }
+
+  return levenshteinDistance(queryToken, candidate) <= maxDistance;
+}
+
+function maxAllowedDistance(length: number): number {
+  if (length <= 5) {
+    return 1;
+  }
+
+  if (length <= 8) {
+    return 2;
+  }
+
+  return Math.ceil(length * 0.25);
+}
+
+function tokenizeSearchText(value: string): string[] {
+  return normalizeSearchText(value).split(' ').filter(Boolean);
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function levenshteinDistance(source: string, target: string): number {
+  const previous = Array.from({ length: target.length + 1 }, (_, index) => index);
+  const current = Array.from({ length: target.length + 1 }, () => 0);
+
+  for (let sourceIndex = 1; sourceIndex <= source.length; sourceIndex += 1) {
+    current[0] = sourceIndex;
+
+    for (let targetIndex = 1; targetIndex <= target.length; targetIndex += 1) {
+      const cost = source[sourceIndex - 1] === target[targetIndex - 1] ? 0 : 1;
+      current[targetIndex] = Math.min(
+        current[targetIndex - 1] + 1,
+        previous[targetIndex] + 1,
+        previous[targetIndex - 1] + cost,
+      );
+    }
+
+    for (let index = 0; index < previous.length; index += 1) {
+      previous[index] = current[index];
+    }
+  }
+
+  return previous[target.length];
+}

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,5 +1,18 @@
 import type { PostMeta } from '@/types/blog';
 
+/**
+ * Blog search uses a lightweight token-level Levenshtein matcher.
+ *
+ * 1. Normalize query and searchable fields with NFKC, lowercase, punctuation stripping, and
+ *    whitespace folding.
+ * 2. Run exact phrase matching inside each field only, so title/description boundaries do not
+ *    create false positives.
+ * 3. For typo tolerance, require every query token to match at least one token from title,
+ *    description, category, or tags.
+ * 4. Fuzzy matching is disabled for tokens shorter than four characters. Longer tokens use a
+ *    conservative edit-distance threshold: <=5 chars allow one edit, <=8 chars allow two edits,
+ *    and longer tokens allow roughly 25% edits.
+ */
 const MIN_FUZZY_TOKEN_LENGTH = 4;
 
 export function matchesPostSearch(post: PostMeta, rawQuery: string): boolean {


### PR DESCRIPTION
## Summary
- include post descriptions in blog search matching
- add typo-tolerant fuzzy matching for search tokens
- preserve category/tag search behavior through the shared search utility

## Verification
- KNOWLEDGE_BASE_PATH=.cache/knowledge-base bun run verify
- pre-push next build

Closes #81