### PR TITLE
Harden code structure and logging

### DIFF
--- a/scripts/check-repo-governance.ts
+++ b/scripts/check-repo-governance.ts
@@ -100,6 +100,32 @@ const PRIVATE_LOG_HYGIENE_PATTERNS = [
   },
 ];
 
+const STRUCTURAL_SMELL_PATTERNS = [
+  {
+    file: 'src/utils/search.ts',
+    forbidden: ['previous[index] = current[index]'],
+    message: 'search Levenshtein rows must be swapped instead of copied on every iteration.',
+  },
+  {
+    file: 'src/components/sections/RecentPosts/RecentPosts.tsx',
+    forbidden: ['posts\n    .sort(', '[animation-delay:${'],
+    message: 'RecentPosts must not mutate props or build dynamic Tailwind classes at runtime.',
+  },
+  {
+    file: 'src/app/page.tsx',
+    forbidden: ['new Set(posts.map(post => post.category.text))'],
+    message: 'page-level post filter data must come from shared blog utils.',
+  },
+  {
+    file: 'src/app/blog/page.tsx',
+    forbidden: [
+      'new Set(posts.map(post => post.category.text))',
+      'new Set(posts.flatMap(post => post.tags))',
+    ],
+    message: 'page-level post filter data must come from shared blog utils.',
+  },
+];
+
 interface PackageJson {
   scripts?: Record<string, string>;
   dependencies?: Record<string, string>;
@@ -140,6 +166,10 @@ function walkFiles(root: string): string[] {
   }
 
   return result;
+}
+
+function stripSourceComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
 }
 
 function checkRequiredFiles(errors: string[]) {
@@ -214,6 +244,52 @@ function checkPrivateLogHygiene(errors: string[]) {
       if (text.includes(snippet)) {
         errors.push(`${file}: build logs must not expose private content paths by default.`);
       }
+    }
+  }
+}
+
+function checkStructuralSmellPatterns(errors: string[]) {
+  for (const { file, forbidden, message } of STRUCTURAL_SMELL_PATTERNS) {
+    const text = readText(file);
+    for (const snippet of forbidden) {
+      if (text.includes(snippet)) {
+        errors.push(`${file}: ${message}`);
+      }
+    }
+  }
+
+  const blogPosts = readText('src/components/sections/BlogPosts/BlogPosts.tsx');
+  const ascendingSortLabelCount = blogPosts.match(/오름차순 정렬/g)?.length ?? 0;
+  const descendingSortLabelCount = blogPosts.match(/내림차순 정렬/g)?.length ?? 0;
+
+  if (ascendingSortLabelCount !== 1 || descendingSortLabelCount !== 1) {
+    errors.push('BlogPosts sort controls must be implemented once and reused across states.');
+  }
+
+  const blogUtils = readText('src/utils/blog.ts');
+  if (!blogUtils.includes('return `/blog/?${params.toString()}`;')) {
+    errors.push('createBlogFilterHref must preserve the existing /blog/?query URL shape.');
+  }
+}
+
+function checkProductionLogging(errors: string[]) {
+  const sourceFiles = walkFiles(path.join(PROJECT_ROOT, 'src')).filter(filePath => {
+    const relativePath = path.relative(PROJECT_ROOT, filePath);
+    return (
+      /\.(ts|tsx)$/.test(filePath) &&
+      !relativePath.endsWith('.test.ts') &&
+      !relativePath.endsWith('.test.tsx') &&
+      !relativePath.endsWith('.stories.tsx') &&
+      relativePath !== 'src/utils/logger.ts'
+    );
+  });
+
+  for (const filePath of sourceFiles) {
+    const source = stripSourceComments(fs.readFileSync(filePath, 'utf8'));
+    if (/console\.(debug|error|info|log|warn)\s*\(/.test(source)) {
+      errors.push(
+        `${path.relative(PROJECT_ROOT, filePath)}: production code must use src/utils/logger.ts instead of raw console calls.`,
+      );
     }
   }
 }
@@ -525,6 +601,8 @@ function main() {
   checkRequiredFiles(errors);
   checkGeneratedArtifactsIgnored(errors);
   checkPrivateLogHygiene(errors);
+  checkStructuralSmellPatterns(errors);
+  checkProductionLogging(errors);
   checkPackageScripts(errors);
   checkWorkflows(errors);
   checkKbPathResolution(errors);

--- a/scripts/check-repo-governance.ts
+++ b/scripts/check-repo-governance.ts
@@ -107,11 +107,6 @@ const STRUCTURAL_SMELL_PATTERNS = [
     message: 'search Levenshtein rows must be swapped instead of copied on every iteration.',
   },
   {
-    file: 'src/components/sections/RecentPosts/RecentPosts.tsx',
-    forbidden: ['posts\n    .sort(', '[animation-delay:${'],
-    message: 'RecentPosts must not mutate props or build dynamic Tailwind classes at runtime.',
-  },
-  {
     file: 'src/app/page.tsx',
     forbidden: ['new Set(posts.map(post => post.category.text))'],
     message: 'page-level post filter data must come from shared blog utils.',
@@ -169,7 +164,85 @@ function walkFiles(root: string): string[] {
 }
 
 function stripSourceComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  let result = '';
+  let state:
+    | 'code'
+    | 'single-quote'
+    | 'double-quote'
+    | 'template'
+    | 'line-comment'
+    | 'block-comment' = 'code';
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const nextChar = text[index + 1];
+
+    if (state === 'line-comment') {
+      if (char === '\n') {
+        result += char;
+        state = 'code';
+      }
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      if (char === '*' && nextChar === '/') {
+        index += 1;
+        state = 'code';
+        continue;
+      }
+
+      if (char === '\n') {
+        result += char;
+      }
+      continue;
+    }
+
+    if (state === 'single-quote' || state === 'double-quote' || state === 'template') {
+      result += char;
+
+      if (char === '\\') {
+        if (typeof nextChar !== 'undefined') {
+          result += nextChar;
+          index += 1;
+        }
+        continue;
+      }
+
+      if (
+        (state === 'single-quote' && char === "'") ||
+        (state === 'double-quote' && char === '"') ||
+        (state === 'template' && char === '`')
+      ) {
+        state = 'code';
+      }
+      continue;
+    }
+
+    if (char === '/' && nextChar === '/') {
+      state = 'line-comment';
+      index += 1;
+      continue;
+    }
+
+    if (char === '/' && nextChar === '*') {
+      state = 'block-comment';
+      index += 1;
+      continue;
+    }
+
+    result += char;
+
+    if (char === "'") {
+      state = 'single-quote';
+    } else if (char === '"') {
+      state = 'double-quote';
+    } else if (char === '`') {
+      state = 'template';
+    }
+  }
+
+  return result;
 }
 
 function checkRequiredFiles(errors: string[]) {
@@ -266,9 +339,46 @@ function checkStructuralSmellPatterns(errors: string[]) {
     errors.push('BlogPosts sort controls must be implemented once and reused across states.');
   }
 
+  const recentPosts = readText('src/components/sections/RecentPosts/RecentPosts.tsx');
+  if (/\bposts\s*\.\s*sort\s*\(/.test(recentPosts)) {
+    errors.push('RecentPosts must not mutate the posts prop while sorting.');
+  }
+
+  if (recentPosts.includes('style={{ animationDelay')) {
+    errors.push('RecentPosts must preserve the existing class-based animation delay rendering.');
+  }
+
   const blogUtils = readText('src/utils/blog.ts');
   if (!blogUtils.includes('return `/blog/?${params.toString()}`;')) {
     errors.push('createBlogFilterHref must preserve the existing /blog/?query URL shape.');
+  }
+}
+
+function checkSourceCommentStripping(errors: string[]) {
+  const stripped = stripSourceComments(`
+const docsUrl = 'https://example.com/docs';
+const apiUrl = "http://example.com/api";
+console.warn('visible runtime log');
+// console.error('hidden line comment log');
+/* console.warn('hidden block comment log'); */
+`);
+
+  if (
+    !stripped.includes('https://example.com/docs') ||
+    !stripped.includes('http://example.com/api')
+  ) {
+    errors.push('Source comment stripping must preserve URL strings.');
+  }
+
+  if (!stripped.includes("console.warn('visible runtime log')")) {
+    errors.push('Source comment stripping must preserve executable source.');
+  }
+
+  if (
+    stripped.includes('hidden line comment log') ||
+    stripped.includes('hidden block comment log')
+  ) {
+    errors.push('Source comment stripping must remove real comments.');
   }
 }
 
@@ -602,6 +712,7 @@ function main() {
   checkGeneratedArtifactsIgnored(errors);
   checkPrivateLogHygiene(errors);
   checkStructuralSmellPatterns(errors);
+  checkSourceCommentStripping(errors);
   checkProductionLogging(errors);
   checkPackageScripts(errors);
   checkWorkflows(errors);

--- a/scripts/check-repo-governance.ts
+++ b/scripts/check-repo-governance.ts
@@ -355,18 +355,17 @@ function checkStructuralSmellPatterns(errors: string[]) {
 }
 
 function checkSourceCommentStripping(errors: string[]) {
+  const docsUrl = ['https:', '//example.com/docs'].join('');
+  const apiUrl = ['http:', '//example.com/api'].join('');
   const stripped = stripSourceComments(`
-const docsUrl = 'https://example.com/docs';
-const apiUrl = "http://example.com/api";
+const docsUrl = '${docsUrl}';
+const apiUrl = "${apiUrl}";
 console.warn('visible runtime log');
 // console.error('hidden line comment log');
 /* console.warn('hidden block comment log'); */
 `);
 
-  if (
-    !stripped.includes('https://example.com/docs') ||
-    !stripped.includes('http://example.com/api')
-  ) {
+  if (!stripped.includes(docsUrl) || !stripped.includes(apiUrl)) {
     errors.push('Source comment stripping must preserve URL strings.');
   }
 

--- a/scripts/check-repo-governance.ts
+++ b/scripts/check-repo-governance.ts
@@ -3,6 +3,8 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import ts from 'typescript';
+
 import { PROJECT_ROOT } from './content-paths.js';
 
 const REQUIRED_VERIFY_STEPS = [
@@ -67,6 +69,7 @@ const REQUIRED_FILES = [
 ];
 
 const GENERATED_ARTIFACT_PATTERNS = ['content/posts/', 'public/content/', 'public/data/'];
+const PRODUCTION_CONSOLE_METHODS = new Set(['debug', 'error', 'info', 'log', 'warn']);
 
 const PRIVATE_LOG_HYGIENE_PATTERNS = [
   {
@@ -157,88 +160,6 @@ function walkFiles(root: string): string[] {
 
     if (entry.isFile()) {
       result.push(absolutePath);
-    }
-  }
-
-  return result;
-}
-
-function stripSourceComments(text: string): string {
-  let result = '';
-  let state:
-    | 'code'
-    | 'single-quote'
-    | 'double-quote'
-    | 'template'
-    | 'line-comment'
-    | 'block-comment' = 'code';
-
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    const nextChar = text[index + 1];
-
-    if (state === 'line-comment') {
-      if (char === '\n') {
-        result += char;
-        state = 'code';
-      }
-      continue;
-    }
-
-    if (state === 'block-comment') {
-      if (char === '*' && nextChar === '/') {
-        index += 1;
-        state = 'code';
-        continue;
-      }
-
-      if (char === '\n') {
-        result += char;
-      }
-      continue;
-    }
-
-    if (state === 'single-quote' || state === 'double-quote' || state === 'template') {
-      result += char;
-
-      if (char === '\\') {
-        if (typeof nextChar !== 'undefined') {
-          result += nextChar;
-          index += 1;
-        }
-        continue;
-      }
-
-      if (
-        (state === 'single-quote' && char === "'") ||
-        (state === 'double-quote' && char === '"') ||
-        (state === 'template' && char === '`')
-      ) {
-        state = 'code';
-      }
-      continue;
-    }
-
-    if (char === '/' && nextChar === '/') {
-      state = 'line-comment';
-      index += 1;
-      continue;
-    }
-
-    if (char === '/' && nextChar === '*') {
-      state = 'block-comment';
-      index += 1;
-      continue;
-    }
-
-    result += char;
-
-    if (char === "'") {
-      state = 'single-quote';
-    } else if (char === '"') {
-      state = 'double-quote';
-    } else if (char === '`') {
-      state = 'template';
     }
   }
 
@@ -354,30 +275,75 @@ function checkStructuralSmellPatterns(errors: string[]) {
   }
 }
 
-function checkSourceCommentStripping(errors: string[]) {
-  const docsUrl = ['https:', '//example.com/docs'].join('');
-  const apiUrl = ['http:', '//example.com/api'].join('');
-  const stripped = stripSourceComments(`
-const docsUrl = '${docsUrl}';
-const apiUrl = "${apiUrl}";
-console.warn('visible runtime log');
-// console.error('hidden line comment log');
-/* console.warn('hidden block comment log'); */
-`);
-
-  if (!stripped.includes(docsUrl) || !stripped.includes(apiUrl)) {
-    errors.push('Source comment stripping must preserve URL strings.');
-  }
-
-  if (!stripped.includes("console.warn('visible runtime log')")) {
-    errors.push('Source comment stripping must preserve executable source.');
+function getConsoleCallMethodName(expression: ts.Expression): string | null {
+  if (
+    ts.isPropertyAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'console'
+  ) {
+    return expression.name.text;
   }
 
   if (
-    stripped.includes('hidden line comment log') ||
-    stripped.includes('hidden block comment log')
+    ts.isElementAccessExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'console' &&
+    ts.isStringLiteralLike(expression.argumentExpression)
   ) {
-    errors.push('Source comment stripping must remove real comments.');
+    return expression.argumentExpression.text;
+  }
+
+  return null;
+}
+
+function sourceHasProductionConsoleCall(source: string, fileName: string): boolean {
+  const scriptKind =
+    fileName.endsWith('.tsx') || fileName.endsWith('.jsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  let hasConsoleCall = false;
+
+  function visit(node: ts.Node) {
+    if (hasConsoleCall) {
+      return;
+    }
+
+    if (ts.isCallExpression(node)) {
+      const methodName = getConsoleCallMethodName(node.expression);
+      if (methodName && PRODUCTION_CONSOLE_METHODS.has(methodName)) {
+        hasConsoleCall = true;
+        return;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return hasConsoleCall;
+}
+
+function checkProductionConsoleDetection(errors: string[]) {
+  const executableConsole = `
+const absoluteUrlPattern = /^(https?:)?\\/\\//i; console.warn('visible runtime log');
+`;
+  const nonExecutableConsole = `
+const text = "console.log('hidden string log')";
+// console.error('hidden line comment log');
+/* console.warn('hidden block comment log'); */
+`;
+
+  if (!sourceHasProductionConsoleCall(executableConsole, 'fixture.ts')) {
+    errors.push('Production console detection must handle regex literals before console calls.');
+  }
+
+  if (sourceHasProductionConsoleCall(nonExecutableConsole, 'fixture.ts')) {
+    errors.push('Production console detection must ignore strings and comments.');
   }
 }
 
@@ -394,8 +360,8 @@ function checkProductionLogging(errors: string[]) {
   });
 
   for (const filePath of sourceFiles) {
-    const source = stripSourceComments(fs.readFileSync(filePath, 'utf8'));
-    if (/console\.(debug|error|info|log|warn)\s*\(/.test(source)) {
+    const source = fs.readFileSync(filePath, 'utf8');
+    if (sourceHasProductionConsoleCall(source, filePath)) {
       errors.push(
         `${path.relative(PROJECT_ROOT, filePath)}: production code must use src/utils/logger.ts instead of raw console calls.`,
       );
@@ -711,7 +677,7 @@ function main() {
   checkGeneratedArtifactsIgnored(errors);
   checkPrivateLogHygiene(errors);
   checkStructuralSmellPatterns(errors);
-  checkSourceCommentStripping(errors);
+  checkProductionConsoleDetection(errors);
   checkProductionLogging(errors);
   checkPackageScripts(errors);
   checkWorkflows(errors);

--- a/src/__tests__/libs/seo/postMetadata.test.ts
+++ b/src/__tests__/libs/seo/postMetadata.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { generatePostJsonLd, serializeJsonLd } from '@/libs/seo/postMetadata';
+
+describe('post metadata helpers', () => {
+  it('serializes JSON-LD without allowing script context breakout', () => {
+    const jsonLd = generatePostJsonLd({
+      title: '</script><script>alert(1)</script>',
+      description: 'Unsafe <tag> & separator \u2028 \u2029',
+      canonical: '/blog/security',
+    });
+
+    const serialized = serializeJsonLd(jsonLd);
+
+    expect(serialized).not.toContain('</script>');
+    expect(serialized).not.toContain('<script>');
+    expect(serialized).toContain('\\u003c/script\\u003e');
+    expect(serialized).toContain('\\u0026');
+    expect(serialized).toContain('\\u2028');
+    expect(serialized).toContain('\\u2029');
+    expect(JSON.parse(serialized)).toMatchObject({
+      headline: '</script><script>alert(1)</script>',
+      description: 'Unsafe <tag> & separator \u2028 \u2029',
+    });
+  });
+});

--- a/src/__tests__/utils/blog.test.ts
+++ b/src/__tests__/utils/blog.test.ts
@@ -3,12 +3,17 @@ import { describe, expect, it } from 'vitest';
 import type { PostMeta } from '@/types/blog';
 
 import {
+  createBlogFilterHref,
+  createBlogPostHref,
   convertPostForRendering,
   convertPostsForRendering,
   findPostByEncodedSlug,
   findPostBySlug,
   formatPostDateTimeKST,
+  getPostCategories,
+  getPostTags,
   getTableOfContents,
+  isAllPostsCategory,
 } from '../../utils/blog';
 
 const basePost = {
@@ -54,6 +59,35 @@ describe('Blog Utils', () => {
       expect(findPostBySlug([encodedPost], '한글-제목')).toBe(encodedPost);
       expect(findPostByEncodedSlug([encodedPost], encodedPost.encodedSlug)).toBe(encodedPost);
       expect(findPostByEncodedSlug([encodedPost], 'missing')).toBeNull();
+    });
+
+    it('블로그 포스트와 필터 URL을 기존 경로 형식으로 생성한다', () => {
+      expect(createBlogPostHref({ slug: 'plain-slug' })).toBe('/blog/plain-slug');
+      expect(createBlogPostHref({ slug: '한글-제목', encodedSlug: '%ED%95%9C%EA%B8%80' })).toBe(
+        '/blog/%ED%95%9C%EA%B8%80',
+      );
+      expect(createBlogFilterHref('category', 'Vector Search')).toBe(
+        '/blog/?category=Vector+Search',
+      );
+      expect(createBlogFilterHref('tags', 'Paper Review')).toBe('/blog/?tags=Paper+Review');
+    });
+
+    it('포스트 목록에서 전체 카테고리와 태그 필터 값을 파생한다', () => {
+      const posts = [
+        basePost,
+        {
+          ...basePost,
+          id: 2,
+          category: { text: 'report', color: 'blue' as const },
+          tags: ['kb', 'report'],
+        },
+      ];
+
+      expect(getPostCategories(posts)).toEqual(['전체', 'wiki', 'report']);
+      expect(getPostTags(posts)).toEqual(['kb', 'report']);
+      expect(isAllPostsCategory(undefined)).toBe(true);
+      expect(isAllPostsCategory('전체')).toBe(true);
+      expect(isAllPostsCategory('wiki')).toBe(false);
     });
   });
 

--- a/src/__tests__/utils/logger.test.ts
+++ b/src/__tests__/utils/logger.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { logError, logWarn } from '@/utils/logger';
+
+describe('logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps the original detail object outside production for debugging', () => {
+    const error = new Error('Detailed failure');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logError('Content load failed', error);
+
+    expect(consoleSpy).toHaveBeenCalledWith('[Content load failed]', error);
+  });
+
+  it('hides detail in production logs', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    logWarn('Content path is unavailable', 'Private local path detail');
+
+    expect(consoleSpy).toHaveBeenCalledWith('[Content path is unavailable]');
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      '[Content path is unavailable]',
+      'Private local path detail',
+    );
+  });
+});

--- a/src/app/blog/BlogPageClient.tsx
+++ b/src/app/blog/BlogPageClient.tsx
@@ -5,8 +5,9 @@ import React, { useState, useMemo, Suspense, useEffect, startTransition } from '
 
 import { BlogTemplate } from '@/components/templates/BlogTemplate';
 import type { PostRowProps } from '@/components/ui/blog/PostRow';
+import { BLOG_POSTS_PER_PAGE } from '@/constants/blog';
 import type { PostMeta } from '@/types/blog';
-import { convertPostsForRendering } from '@/utils/blog';
+import { convertPostsForRendering, isAllPostsCategory } from '@/utils/blog';
 import { filterPostsBySearch } from '@/utils/search';
 
 interface BlogPageClientProps {
@@ -32,7 +33,7 @@ function BlogPageContent({ initialPosts, initialCategories, initialTags }: BlogP
   const [currentPage, setCurrentPage] = useState(1);
   const [isHydrated, setIsHydrated] = useState(false);
 
-  const postsPerPage = 6;
+  const postsPerPage = BLOG_POSTS_PER_PAGE;
 
   // Hydration 완료 후 URL 파라미터에서 초기값 설정
   useEffect(() => {
@@ -58,7 +59,7 @@ function BlogPageContent({ initialPosts, initialCategories, initialTags }: BlogP
     }
 
     // 카테고리 필터링
-    if (selectedCategory && selectedCategory !== '전체') {
+    if (!isAllPostsCategory(selectedCategory)) {
       filtered = filtered.filter(post => post.category.text === selectedCategory);
     }
 
@@ -97,8 +98,9 @@ function BlogPageContent({ initialPosts, initialCategories, initialTags }: BlogP
       newParams.set('search', params.search);
     }
 
-    if (params.category && params.category !== '전체') {
-      newParams.set('category', params.category);
+    const category = params.category;
+    if (category && !isAllPostsCategory(category)) {
+      newParams.set('category', category);
     }
 
     if (params.tags && params.tags.length > 0) {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,13 +6,15 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import { PostTemplate } from '@/components/templates/PostTemplate';
+import { DEFAULT_POSTS_PER_PAGE } from '@/constants/blog';
 import { extractTableOfContentsFromMarkdown } from '@/libs/content';
 import type { ContentLinkMaps } from '@/libs/content';
-import { generatePostJsonLd, generatePostMetadata } from '@/libs/seo/postMetadata';
+import { generatePostJsonLd, generatePostMetadata, serializeJsonLd } from '@/libs/seo/postMetadata';
 import { getPostListWithStaticFallback } from '@/libs/staticPostData';
 import type { PostMeta } from '@/types/blog';
-import { findPostByEncodedSlug } from '@/utils/blog';
+import { createBlogPostHref, findPostByEncodedSlug } from '@/utils/blog';
 import { getSiteConfig } from '@/utils/config';
+import { logError, logWarn } from '@/utils/logger';
 
 interface PostPageProps {
   params: Promise<{
@@ -50,7 +52,7 @@ function readContentLinkMaps(): ContentLinkMaps {
   try {
     return JSON.parse(fs.readFileSync(LINK_INDEX_PATH, 'utf8')) as ContentLinkMaps;
   } catch (error) {
-    console.warn('Failed to parse content link index:', error);
+    logWarn('Content link index parse failed', error);
     return emptyContentLinkMaps();
   }
 }
@@ -66,7 +68,7 @@ export async function generateStaticParams() {
       slug: post.slug,
     }));
   } catch (error) {
-    console.error('❌ [generateStaticParams] Error generating static params:', error);
+    logError('Blog static params generation failed', error);
     return [];
   }
 }
@@ -99,7 +101,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
       author: siteConfig.author.name,
     });
   } catch (error) {
-    console.error('Error generating metadata:', error);
+    logError('Blog post metadata generation failed', error);
     return {
       title: 'Post Not Found',
     };
@@ -148,18 +150,18 @@ export default async function PostPage({ params }: PostPageProps) {
       id: p.id,
       title: p.title,
       createdAt: p.createdAt,
-      href: `/blog/${p.encodedSlug || p.slug}`,
+      href: createBlogPostHref(p),
     }));
 
   // 관련 포스트 페이지네이션 설정 (5개 이상일 때 활성화)
-  const postsPerPage = 5;
+  const postsPerPage = DEFAULT_POSTS_PER_PAGE;
   const enablePagination = relatedPosts.length > postsPerPage;
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       <PostTemplate
         post={{
@@ -172,7 +174,7 @@ export default async function PostPage({ params }: PostPageProps) {
           prevPost
             ? {
                 title: prevPost.title,
-                href: `/blog/${prevPost.encodedSlug || prevPost.slug}`,
+                href: createBlogPostHref(prevPost),
               }
             : undefined
         }
@@ -180,7 +182,7 @@ export default async function PostPage({ params }: PostPageProps) {
           nextPost
             ? {
                 title: nextPost.title,
-                href: `/blog/${nextPost.encodedSlug || nextPost.slug}`,
+                href: createBlogPostHref(nextPost),
               }
             : undefined
         }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { getPostListWithStaticFallback } from '@/libs/staticPostData';
+import { getPostCategories, getPostTags } from '@/utils/blog';
+import { logError } from '@/utils/logger';
 
 import BlogPageClient from './BlogPageClient';
 
@@ -11,7 +13,7 @@ import BlogPageClient from './BlogPageClient';
 export default async function BlogPage() {
   // 빌드 타임에 정적 데이터 가져오기
   const result = await getPostListWithStaticFallback().catch(error => {
-    console.error('Failed to load blog posts:', error);
+    logError('Blog posts load failed', error);
     return null;
   });
 
@@ -20,9 +22,8 @@ export default async function BlogPage() {
   }
 
   const posts = result;
-  // 카테고리와 태그 추출
-  const categories = ['전체', ...Array.from(new Set(posts.map(post => post.category.text)))];
-  const tags = Array.from(new Set(posts.flatMap(post => post.tags)));
+  const categories = getPostCategories(posts);
+  const tags = getPostTags(posts);
 
   return <BlogPageClient initialPosts={posts} initialCategories={categories} initialTags={tags} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { LandingTemplate } from '@/components/templates/LandingTemplate';
 import { getPostListWithStaticFallback } from '@/libs/staticPostData';
+import { getPostCategories } from '@/utils/blog';
+import { logError } from '@/utils/logger';
 
 /**
  * 메인 페이지 (Landing Page)
@@ -10,12 +12,12 @@ import { getPostListWithStaticFallback } from '@/libs/staticPostData';
 export default async function LandingPage() {
   // 빌드 타임에 정적 데이터 가져오기
   const result = await getPostListWithStaticFallback().catch(error => {
-    console.error('Failed to load posts:', error);
+    logError('Landing posts load failed', error);
     return null;
   });
 
   const posts = result ?? [];
-  const categories = ['전체', ...Array.from(new Set(posts.map(post => post.category.text)))];
+  const categories = getPostCategories(posts);
   const emptyMessage = result === null ? '포스트를 불러오는 중 오류가 발생했습니다.' : '';
 
   return (

--- a/src/components/sections/BlogPosts/BlogPosts.tsx
+++ b/src/components/sections/BlogPosts/BlogPosts.tsx
@@ -7,6 +7,26 @@ import { PaginationBar } from '@/components/ui/pagination/PaginationBar';
 export type SortOption = 'id';
 export type SortDirection = 'asc' | 'desc';
 
+const CONTAINER_STYLES = 'w-full max-w-4xl mx-auto transition-colors duration-200';
+const LIST_CONTAINER_STYLES = 'relative transition-colors duration-200';
+const BLOG_POSTS_SKELETON_COUNT = 5;
+const SORT_OPTIONS: Array<{
+  direction: SortDirection;
+  label: string;
+  Icon: typeof ChevronUp;
+}> = [
+  {
+    direction: 'asc',
+    label: '오름차순 정렬',
+    Icon: ChevronUp,
+  },
+  {
+    direction: 'desc',
+    label: '내림차순 정렬',
+    Icon: ChevronDown,
+  },
+];
+
 export interface BlogPostsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /**
    * 블로그 포스트 목록
@@ -84,6 +104,43 @@ export interface BlogPostsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ch
   className?: string;
 }
 
+interface SortControlsProps {
+  sortDirection: SortDirection;
+  onSortChange?: (sortBy: SortOption, direction: SortDirection) => void;
+}
+
+function SortControls({ sortDirection, onSortChange }: SortControlsProps) {
+  return (
+    <div className="flex items-center gap-2 mb-4 px-2">
+      <span className="text-[color:var(--color-text)] font-pretendard font-bold text-sm">정렬</span>
+      <div className="flex items-center">
+        {SORT_OPTIONS.map(({ direction, label, Icon }) => {
+          const isSelected = sortDirection === direction;
+
+          return (
+            <button
+              key={direction}
+              onClick={() => {
+                onSortChange?.('id', direction);
+              }}
+              className={`p-1 rounded transition-colors focus:outline-none focus-visible:outline-none ${
+                isSelected
+                  ? 'pointer-events-none opacity-50 cursor-not-allowed'
+                  : 'hover:bg-[color:var(--color-primary)] cursor-pointer'
+              }`}
+              disabled={isSelected}
+              aria-label={label}
+              aria-pressed={isSelected}
+            >
+              <Icon className="size-4 text-[color:var(--color-text)]" />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 /**
  * BlogPosts 컴포넌트
  * 블로그 포스트 목록을 행 형태로 표시하고 페이지네이션을 제공하는 organism 컴포넌트
@@ -109,19 +166,10 @@ export const BlogPosts = forwardRef<HTMLDivElement, BlogPostsProps>(
     },
     ref,
   ) => {
-    // 기본 스타일 클래스들
-    const containerStyles = ['w-full max-w-4xl mx-auto', 'transition-colors duration-200']
-      .filter(Boolean)
-      .join(' ');
-
-    const listContainerStyles = ['relative', 'transition-colors duration-200']
-      .filter(Boolean)
-      .join(' ');
-
     // 로딩 상태 렌더링
     if (isLoading) {
       return (
-        <div ref={ref} className={`${containerStyles} ${className}`} {...props}>
+        <div ref={ref} className={`${CONTAINER_STYLES} ${className}`} {...props}>
           {/* 정렬 옵션 */}
           {showSort && (
             <div className="flex items-center gap-2 mb-4 px-2">
@@ -136,8 +184,8 @@ export const BlogPosts = forwardRef<HTMLDivElement, BlogPostsProps>(
           )}
 
           {/* 로딩 스켈레톤 */}
-          <div className={listContainerStyles}>
-            {Array.from({ length: 5 }).map((_, index) => (
+          <div className={LIST_CONTAINER_STYLES}>
+            {Array.from({ length: BLOG_POSTS_SKELETON_COUNT }).map((_, index) => (
               <div
                 key={index}
                 className="flex flex-col md:flex-row w-full border-b border-[color:var(--color-secondary)] py-8 px-6 animate-pulse"
@@ -166,48 +214,12 @@ export const BlogPosts = forwardRef<HTMLDivElement, BlogPostsProps>(
     // 빈 상태 렌더링
     if (posts.length === 0) {
       return (
-        <div ref={ref} className={`${containerStyles} ${className}`} {...props}>
+        <div ref={ref} className={`${CONTAINER_STYLES} ${className}`} {...props}>
           {/* 정렬 옵션 */}
-          {showSort && (
-            <div className="flex items-center gap-2 mb-4 px-2">
-              <span className="text-[color:var(--color-text)] font-pretendard font-bold text-sm">
-                정렬
-              </span>
-              <div className="flex items-center">
-                {/* 오름차순 버튼 */}
-                <button
-                  onClick={() => onSortChange?.('id', 'asc')}
-                  className={`p-1 rounded transition-colors focus:outline-none focus-visible:outline-none ${
-                    sortDirection === 'asc'
-                      ? 'pointer-events-none opacity-50 cursor-not-allowed'
-                      : 'hover:bg-[color:var(--color-primary)] cursor-pointer'
-                  }`}
-                  disabled={sortDirection === 'asc'}
-                  aria-label="오름차순 정렬"
-                  aria-pressed={sortDirection === 'asc'}
-                >
-                  <ChevronUp className="size-4 text-[color:var(--color-text)]" />
-                </button>
-                {/* 내림차순 버튼 */}
-                <button
-                  onClick={() => onSortChange?.('id', 'desc')}
-                  className={`p-1 rounded transition-colors focus:outline-none focus-visible:outline-none ${
-                    sortDirection === 'desc'
-                      ? 'pointer-events-none opacity-50 cursor-not-allowed'
-                      : 'hover:bg-[color:var(--color-primary)] cursor-pointer'
-                  }`}
-                  disabled={sortDirection === 'desc'}
-                  aria-label="내림차순 정렬"
-                  aria-pressed={sortDirection === 'desc'}
-                >
-                  <ChevronDown className="size-4 text-[color:var(--color-text)]" />
-                </button>
-              </div>
-            </div>
-          )}
+          {showSort && <SortControls sortDirection={sortDirection} onSortChange={onSortChange} />}
 
           {/* 빈 상태 */}
-          <div className={`${listContainerStyles} flex items-center justify-center py-16`}>
+          <div className={`${LIST_CONTAINER_STYLES} flex items-center justify-center py-16`}>
             <div className="text-center">
               <div className="text-[color:var(--color-text)] opacity-60 text-lg font-medium mb-2">
                 📝
@@ -220,48 +232,12 @@ export const BlogPosts = forwardRef<HTMLDivElement, BlogPostsProps>(
     }
 
     return (
-      <div ref={ref} className={`${containerStyles} ${className}`} {...props}>
+      <div ref={ref} className={`${CONTAINER_STYLES} ${className}`} {...props}>
         {/* 정렬 옵션 */}
-        {showSort && (
-          <div className="flex items-center gap-2 mb-4 px-2">
-            <span className="text-[color:var(--color-text)] font-pretendard font-bold text-sm">
-              정렬
-            </span>
-            <div className="flex items-center">
-              {/* 오름차순 버튼 */}
-              <button
-                onClick={() => onSortChange?.('id', 'asc')}
-                className={`p-1 rounded transition-colors focus:outline-none focus-visible:outline-none ${
-                  sortDirection === 'asc'
-                    ? 'pointer-events-none opacity-50 cursor-not-allowed'
-                    : 'hover:bg-[color:var(--color-primary)] cursor-pointer'
-                }`}
-                disabled={sortDirection === 'asc'}
-                aria-label="오름차순 정렬"
-                aria-pressed={sortDirection === 'asc'}
-              >
-                <ChevronUp className="size-4 text-[color:var(--color-text)]" />
-              </button>
-              {/* 내림차순 버튼 */}
-              <button
-                onClick={() => onSortChange?.('id', 'desc')}
-                className={`p-1 rounded transition-colors focus:outline-none focus-visible:outline-none ${
-                  sortDirection === 'desc'
-                    ? 'pointer-events-none opacity-50 cursor-not-allowed'
-                    : 'hover:bg-[color:var(--color-primary)] cursor-pointer'
-                }`}
-                disabled={sortDirection === 'desc'}
-                aria-label="내림차순 정렬"
-                aria-pressed={sortDirection === 'desc'}
-              >
-                <ChevronDown className="size-4 text-[color:var(--color-text)]" />
-              </button>
-            </div>
-          </div>
-        )}
+        {showSort && <SortControls sortDirection={sortDirection} onSortChange={onSortChange} />}
 
         {/* 포스트 목록 */}
-        <div className={listContainerStyles}>
+        <div className={LIST_CONTAINER_STYLES}>
           {posts.map((post, index) => (
             <PostRow
               key={`${sortDirection}-${post.id}-${index}`}

--- a/src/components/sections/PostComments/PostComments.test.tsx
+++ b/src/components/sections/PostComments/PostComments.test.tsx
@@ -97,9 +97,7 @@ describe('PostComments', () => {
 
     render(<PostComments />);
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      'Missing required environment variables: NEXT_PUBLIC_GISCUS_REPO or NEXT_PUBLIC_GISCUS_REPO_ID',
-    );
+    expect(consoleSpy).toHaveBeenCalledWith('[Giscus configuration is incomplete]');
 
     consoleSpy.mockRestore();
   });

--- a/src/components/sections/PostComments/PostComments.test.tsx
+++ b/src/components/sections/PostComments/PostComments.test.tsx
@@ -97,7 +97,10 @@ describe('PostComments', () => {
 
     render(<PostComments />);
 
-    expect(consoleSpy).toHaveBeenCalledWith('[Giscus configuration is incomplete]');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[Giscus configuration is incomplete]',
+      'Missing NEXT_PUBLIC_GISCUS_REPO or NEXT_PUBLIC_GISCUS_REPO_ID.',
+    );
 
     consoleSpy.mockRestore();
   });

--- a/src/components/sections/PostComments/PostComments.tsx
+++ b/src/components/sections/PostComments/PostComments.tsx
@@ -41,7 +41,10 @@ export function PostComments({ term, className = '' }: PostCommentsProps) {
     if (!commentsRef.current || isGiscusLoadedRef.current) return;
     // 환경 변수 검증
     if (!process.env.NEXT_PUBLIC_GISCUS_REPO || !process.env.NEXT_PUBLIC_GISCUS_REPO_ID) {
-      logError('Giscus configuration is incomplete');
+      logError(
+        'Giscus configuration is incomplete',
+        'Missing NEXT_PUBLIC_GISCUS_REPO or NEXT_PUBLIC_GISCUS_REPO_ID.',
+      );
       return;
     }
 

--- a/src/components/sections/PostComments/PostComments.tsx
+++ b/src/components/sections/PostComments/PostComments.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef } from 'react';
 
 import { THEME_STORAGE_KEY } from '@/constants';
 import { useThemeStore } from '@/store/themeStore';
+import { logError } from '@/utils/logger';
 
 /**
  * PostComments 컴포넌트 Props 인터페이스
@@ -40,9 +41,7 @@ export function PostComments({ term, className = '' }: PostCommentsProps) {
     if (!commentsRef.current || isGiscusLoadedRef.current) return;
     // 환경 변수 검증
     if (!process.env.NEXT_PUBLIC_GISCUS_REPO || !process.env.NEXT_PUBLIC_GISCUS_REPO_ID) {
-      console.error(
-        'Missing required environment variables: NEXT_PUBLIC_GISCUS_REPO or NEXT_PUBLIC_GISCUS_REPO_ID',
-      );
+      logError('Giscus configuration is incomplete');
       return;
     }
 

--- a/src/components/sections/RecentPosts/RecentPosts.test.tsx
+++ b/src/components/sections/RecentPosts/RecentPosts.test.tsx
@@ -199,4 +199,12 @@ describe('RecentPosts', () => {
     const masonryContainer = screen.getByText('Test Post 1').closest('.masonry-grid');
     expect(masonryContainer).toHaveClass('masonry-grid');
   });
+
+  it('does not mutate the posts prop when sorting by date', () => {
+    const posts = [samplePosts[1], samplePosts[0]];
+
+    render(<RecentPosts posts={posts} categories={sampleCategories} selectedCategory="전체" />);
+
+    expect(posts.map(post => post.id)).toEqual([2, 1]);
+  });
 });

--- a/src/components/sections/RecentPosts/RecentPosts.test.tsx
+++ b/src/components/sections/RecentPosts/RecentPosts.test.tsx
@@ -142,6 +142,9 @@ describe('RecentPosts', () => {
       '.flex.items-center.gap-4.overflow-x-hidden',
     );
     expect(categorySkeletons).toHaveLength(1);
+    expect(
+      Array.from(categorySkeletons[0].children).map(element => element.getAttribute('style')),
+    ).toEqual(['width: 72px;', 'width: 88px;', 'width: 64px;', 'width: 96px;', 'width: 80px;']);
 
     // 카드 스켈레톤 확인
     const cardSkeletons = document.querySelectorAll(
@@ -206,5 +209,22 @@ describe('RecentPosts', () => {
     render(<RecentPosts posts={posts} categories={sampleCategories} selectedCategory="전체" />);
 
     expect(posts.map(post => post.id)).toEqual([2, 1]);
+  });
+
+  it('keeps the existing card animation delay classes', () => {
+    render(
+      <RecentPosts posts={samplePosts} categories={sampleCategories} selectedCategory="전체" />,
+    );
+
+    const animatedCards = Array.from(document.querySelectorAll('.animate-fade-in-up')).filter(
+      element => element.className.includes('[animation-delay:'),
+    );
+
+    expect(animatedCards.map(element => element.className)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('[animation-delay:0s]'),
+        expect.stringContaining('[animation-delay:0.1s]'),
+      ]),
+    );
   });
 });

--- a/src/components/sections/RecentPosts/RecentPosts.tsx
+++ b/src/components/sections/RecentPosts/RecentPosts.tsx
@@ -10,7 +10,7 @@ import { Heading } from '@/components/ui/typography';
 import { MAX_RECENT_POSTS } from '@/constants';
 
 const CONTAINER_STYLES = 'mx-auto mb-20';
-const CATEGORY_SKELETON_WIDTHS = ['4.5rem', '5.5rem', '4rem', '6rem', '5rem'];
+const CATEGORY_SKELETON_WIDTHS_PX = [72, 88, 64, 96, 80];
 const MASONRY_BREAKPOINT_COLUMNS = {
   default: 3,
   1024: 2,
@@ -93,12 +93,12 @@ export const RecentPosts = ({
         {/* 카테고리 스켈레톤 */}
         <div className="mb-6">
           <div className="flex items-center gap-4 overflow-x-hidden">
-            {CATEGORY_SKELETON_WIDTHS.map((width, index) => (
+            {CATEGORY_SKELETON_WIDTHS_PX.map((width, index) => (
               <div
                 key={index}
                 className="h-8 bg-[color:var(--color-secondary)] rounded-full flex-shrink-0"
                 style={{
-                  width,
+                  width: `${width}px`,
                 }}
               />
             ))}
@@ -216,9 +216,8 @@ export const RecentPosts = ({
       >
         {displayPosts.map((post, index) => (
           <div
-            key={`${selectedCategory}-${post.id}`}
-            className="mb-6 animate-fade-in-up"
-            style={{ animationDelay: `${0.1 * (index % MAX_RECENT_POSTS)}s` }}
+            key={`${selectedCategory}-${post.id}-${index}`}
+            className={`mb-6 animate-fade-in-up [animation-delay:${0.1 * (index % MAX_RECENT_POSTS)}s]`}
           >
             <PostCard {...post} />
           </div>

--- a/src/components/sections/RecentPosts/RecentPosts.tsx
+++ b/src/components/sections/RecentPosts/RecentPosts.tsx
@@ -8,6 +8,14 @@ import { PostCard, PostCardProps } from '@/components/ui/blog/PostCard';
 import { ExploreButton } from '@/components/ui/buttons/ExploreButton';
 import { Heading } from '@/components/ui/typography';
 import { MAX_RECENT_POSTS } from '@/constants';
+
+const CONTAINER_STYLES = 'mx-auto mb-20';
+const CATEGORY_SKELETON_WIDTHS = ['4.5rem', '5.5rem', '4rem', '6rem', '5rem'];
+const MASONRY_BREAKPOINT_COLUMNS = {
+  default: 3,
+  1024: 2,
+  768: 1,
+};
 /**
  * RecentPosts 컴포넌트 Props
  */
@@ -71,20 +79,10 @@ export const RecentPosts = ({
   onCategoryClick,
   onMoreButtonClick,
 }: RecentPostsProps) => {
-  // 기본 컨테이너 스타일 - 1024px 고정 너비
-  const containerStyles = 'mx-auto mb-20';
-
-  // Masonry breakpoints 설정 - react-masonry-css 방식
-  const breakpointColumnsObj = {
-    default: 3, // 1024px 이상: 3열
-    1024: 2, // 1023px 이하: 2열 (Tailwind lg breakpoint 직전)
-    768: 1, // 767px 이하: 1열 (Tailwind md breakpoint 직전)
-  };
-
   // 로딩 스켈레톤 렌더링
   if (isLoading) {
     return (
-      <div className={`${containerStyles} ${className}`}>
+      <div className={`${CONTAINER_STYLES} ${className}`}>
         {/* 제목 */}
         <div className="mb-8">
           <Heading level={1} fontFamily="maruBuri" className="text-3xl">
@@ -95,12 +93,12 @@ export const RecentPosts = ({
         {/* 카테고리 스켈레톤 */}
         <div className="mb-6">
           <div className="flex items-center gap-4 overflow-x-hidden">
-            {[72, 88, 64, 96, 80].map((width, index) => (
+            {CATEGORY_SKELETON_WIDTHS.map((width, index) => (
               <div
                 key={index}
                 className="h-8 bg-[color:var(--color-secondary)] rounded-full flex-shrink-0"
                 style={{
-                  width: `${width}px`,
+                  width,
                 }}
               />
             ))}
@@ -109,7 +107,7 @@ export const RecentPosts = ({
 
         {/* 포스트 카드 Masonry 스켈레톤 */}
         <Masonry
-          breakpointCols={breakpointColumnsObj}
+          breakpointCols={MASONRY_BREAKPOINT_COLUMNS}
           className="masonry-grid mb-8"
           columnClassName="masonry-grid_column"
         >
@@ -152,7 +150,7 @@ export const RecentPosts = ({
   // 빈 상태 렌더링
   if (posts.length === 0) {
     return (
-      <div className={`${containerStyles} ${className}`}>
+      <div className={`${CONTAINER_STYLES} ${className}`}>
         {/* 제목 */}
         <div className="mb-8">
           <Heading level={1} fontFamily="maruBuri" className="text-3xl">
@@ -185,12 +183,12 @@ export const RecentPosts = ({
   }
 
   // 포스트를 createdAt 기준으로 내림차순 정렬하고 최대 MAX_RECENT_POSTS개까지만 표시
-  const displayPosts = posts
+  const displayPosts = [...posts]
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
     .slice(0, MAX_RECENT_POSTS);
 
   return (
-    <div className={`${containerStyles} ${className}`}>
+    <div className={`${CONTAINER_STYLES} ${className}`}>
       {/* 제목 */}
       <div className="mb-3">
         <Heading level={1} fontFamily="maruBuri" className="text-3xl">
@@ -212,14 +210,15 @@ export const RecentPosts = ({
 
       {/* 블로그 포스트 카드 Masonry 그리드 */}
       <Masonry
-        breakpointCols={breakpointColumnsObj}
+        breakpointCols={MASONRY_BREAKPOINT_COLUMNS}
         className="masonry-grid mb-8 animate-fade-in-up [animation-delay:0.3s]"
         columnClassName="masonry-grid_column"
       >
         {displayPosts.map((post, index) => (
           <div
-            key={`${selectedCategory}-${post.id}-${index}`}
-            className={`mb-6 animate-fade-in-up [animation-delay:${0.1 * (index % MAX_RECENT_POSTS)}s]`}
+            key={`${selectedCategory}-${post.id}`}
+            className="mb-6 animate-fade-in-up"
+            style={{ animationDelay: `${0.1 * (index % MAX_RECENT_POSTS)}s` }}
           >
             <PostCard {...post} />
           </div>

--- a/src/components/templates/LandingTemplate/LandingTemplate.tsx
+++ b/src/components/templates/LandingTemplate/LandingTemplate.tsx
@@ -6,8 +6,9 @@ import React, { useState, useMemo } from 'react';
 import { LandingHero } from '@/components/sections/LandingHero';
 import { RecentPosts, RecentPostsProps } from '@/components/sections/RecentPosts';
 import { PostCardProps } from '@/components/ui/blog/PostCard';
+import { ALL_POSTS_CATEGORY } from '@/constants/blog';
 import { PostMeta } from '@/types/blog';
-import { convertPostsForRendering } from '@/utils/blog';
+import { convertPostsForRendering, isAllPostsCategory } from '@/utils/blog';
 
 /**
  * LandingTemplate 컴포넌트 Props
@@ -64,7 +65,7 @@ export interface LandingTemplateProps {
 export const LandingTemplate = ({
   posts,
   categories,
-  selectedCategory: initialSelectedCategory = '전체',
+  selectedCategory: initialSelectedCategory = ALL_POSTS_CATEGORY,
   showMoreButton = true,
   isLoading = false,
   emptyMessage = '포스트가 없습니다.',
@@ -81,7 +82,7 @@ export const LandingTemplate = ({
   const filteredPosts = useMemo(() => {
     // 카테고리 필터링
     let filtered = posts;
-    if (selectedCategory && selectedCategory !== '전체') {
+    if (!isAllPostsCategory(selectedCategory)) {
       filtered = posts.filter(post => post.category.text === selectedCategory);
     }
 
@@ -99,7 +100,7 @@ export const LandingTemplate = ({
     const params = new URLSearchParams();
 
     // 선택된 카테고리가 '전체'가 아닌 경우만 파라미터 추가
-    if (selectedCategory && selectedCategory !== '전체') {
+    if (!isAllPostsCategory(selectedCategory)) {
       params.set('category', selectedCategory);
     }
 
@@ -112,7 +113,7 @@ export const LandingTemplate = ({
 
   // 선택된 카테고리에 맞는 버튼 텍스트 생성
   const dynamicButtonText = useMemo(() => {
-    if (selectedCategory === '전체') {
+    if (isAllPostsCategory(selectedCategory)) {
       return '전체 글 둘러보기';
     }
     return `${selectedCategory} 글 둘러보기`;

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -6,6 +6,7 @@ import { LabelButton } from '@/components/ui/buttons/LabelButton';
 import { TagButton } from '@/components/ui/buttons/TagButton';
 import { Heading, Text } from '@/components/ui/typography';
 import { PostMeta } from '@/types/blog';
+import { createBlogFilterHref } from '@/utils/blog';
 
 export interface PostHeaderProps extends Omit<PostMeta, 'href'> {
   /**
@@ -20,11 +21,6 @@ export interface PostHeaderProps extends Omit<PostMeta, 'href'> {
    * 태그 클릭 이벤트 핸들러
    */
   onTagClick?: (tag: string) => void;
-}
-
-function createBlogFilterHref(type: 'category' | 'tags', value: string): string {
-  const params = new URLSearchParams({ [type]: value });
-  return `/blog/?${params.toString()}`;
 }
 
 const filterLinkStyles =

--- a/src/constants/blog.ts
+++ b/src/constants/blog.ts
@@ -8,6 +8,16 @@
 export const MAX_RECENT_POSTS = 9;
 
 /**
+ * 블로그 필터에서 전체 카테고리를 나타내는 라벨
+ */
+export const ALL_POSTS_CATEGORY = '전체';
+
+/**
+ * 블로그 목록 페이지에서 페이지당 표시할 포스트 수
+ */
+export const BLOG_POSTS_PER_PAGE = 6;
+
+/**
  * RelatedPosts 컴포넌트에서 페이지당 기본 포스트 수
  */
 export const DEFAULT_POSTS_PER_PAGE = 5;

--- a/src/libs/seo/postMetadata.ts
+++ b/src/libs/seo/postMetadata.ts
@@ -65,6 +65,18 @@ export function generatePostJsonLd({
 }
 
 /**
+ * JSON-LD를 script 태그에 넣을 때 HTML/script context를 깨는 문자를 escape합니다.
+ */
+export function serializeJsonLd(data: Record<string, unknown>): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+/**
  * 블로그 포스트의 SEO 메타데이터 생성을 위한 Props 인터페이스
  */
 export interface PostMetadataProps {

--- a/src/libs/staticPostData.ts
+++ b/src/libs/staticPostData.ts
@@ -17,7 +17,10 @@ const POST_META_PATH = path.join(process.cwd(), 'public', 'data', 'postMeta.json
 export function getStaticPostList(): PostMeta[] {
   try {
     if (!fs.existsSync(POST_META_PATH)) {
-      logWarn('Post metadata file is unavailable');
+      logWarn(
+        'Post metadata file is unavailable',
+        'Run "bun run build:content" and "bun run build:meta" before reading static post metadata.',
+      );
       return [];
     }
 
@@ -56,6 +59,9 @@ export async function getPostListWithStaticFallback(): Promise<PostMeta[]> {
   }
 
   // 정적 데이터가 없으면 빈 배열 반환 (빌드 스크립트를 먼저 실행해야 함)
-  logError('Static post metadata is empty');
+  logError(
+    'Static post metadata is empty',
+    'Run "bun run build:content" and "bun run build:meta" before rendering the app.',
+  );
   return [];
 }

--- a/src/libs/staticPostData.ts
+++ b/src/libs/staticPostData.ts
@@ -9,6 +9,7 @@ import { logError, logWarn } from '@/utils/logger';
 
 // 빌드 시 생성된 postMeta.json 파일 경로
 const POST_META_PATH = path.join(process.cwd(), 'public', 'data', 'postMeta.json');
+const POST_META_BUILD_HINT = 'Run "bun run build:content" and "bun run build:meta".';
 
 /**
  * 정적으로 생성된 포스트 메타데이터를 읽어옵니다
@@ -17,10 +18,7 @@ const POST_META_PATH = path.join(process.cwd(), 'public', 'data', 'postMeta.json
 export function getStaticPostList(): PostMeta[] {
   try {
     if (!fs.existsSync(POST_META_PATH)) {
-      logWarn(
-        'Post metadata file is unavailable',
-        'Run "bun run build:content" and "bun run build:meta" before reading static post metadata.',
-      );
+      logWarn(`Post metadata file is unavailable. ${POST_META_BUILD_HINT}`);
       return [];
     }
 
@@ -59,9 +57,6 @@ export async function getPostListWithStaticFallback(): Promise<PostMeta[]> {
   }
 
   // 정적 데이터가 없으면 빈 배열 반환 (빌드 스크립트를 먼저 실행해야 함)
-  logError(
-    'Static post metadata is empty',
-    'Run "bun run build:content" and "bun run build:meta" before rendering the app.',
-  );
+  logError(`Static post metadata is empty. ${POST_META_BUILD_HINT}`);
   return [];
 }

--- a/src/libs/staticPostData.ts
+++ b/src/libs/staticPostData.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { PostMeta } from '@/types/blog';
+import { logError, logWarn } from '@/utils/logger';
 
 // 빌드 시 생성된 postMeta.json 파일 경로
 const POST_META_PATH = path.join(process.cwd(), 'public', 'data', 'postMeta.json');
@@ -16,7 +17,7 @@ const POST_META_PATH = path.join(process.cwd(), 'public', 'data', 'postMeta.json
 export function getStaticPostList(): PostMeta[] {
   try {
     if (!fs.existsSync(POST_META_PATH)) {
-      console.warn('⚠️ postMeta.json not found. Please run build script first.');
+      logWarn('Post metadata file is unavailable');
       return [];
     }
 
@@ -25,7 +26,7 @@ export function getStaticPostList(): PostMeta[] {
 
     return posts;
   } catch (error) {
-    console.error('❌ Error reading static post list:', error);
+    logError('Static post metadata read failed', error);
     return [];
   }
 }
@@ -38,7 +39,7 @@ export function getStaticPostMeta(pageId: string): PostMeta | null {
     const allPosts = getStaticPostList();
     return allPosts.find(post => post.pageId === pageId) || null;
   } catch (error) {
-    console.error('❌ Error fetching static post meta:', error);
+    logError('Static post metadata lookup failed', error);
     return null;
   }
 }
@@ -55,6 +56,6 @@ export async function getPostListWithStaticFallback(): Promise<PostMeta[]> {
   }
 
   // 정적 데이터가 없으면 빈 배열 반환 (빌드 스크립트를 먼저 실행해야 함)
-  console.error('❌ No static data found. Please run "bun run build:meta" first.');
+  logError('Static post metadata is empty');
   return [];
 }

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -2,6 +2,7 @@ import GithubSlugger from 'github-slugger';
 
 import { PostCardProps } from '@/components/ui/blog/PostCard';
 import { PostRowProps } from '@/components/ui/blog/PostRow';
+import { ALL_POSTS_CATEGORY } from '@/constants/blog';
 import { PostMeta, TableOfContentsItem } from '@/types/blog';
 
 /**
@@ -22,6 +23,27 @@ export function convertPostsForRendering<T extends PostCardProps | PostRowProps>
   posts: PostMeta[],
 ): T[] {
   return posts.map(post => convertPostForRendering<T>(post));
+}
+
+export function createBlogPostHref(post: Pick<PostMeta, 'slug' | 'encodedSlug'>): string {
+  return `/blog/${post.encodedSlug || post.slug}`;
+}
+
+export function createBlogFilterHref(type: 'category' | 'tags', value: string): string {
+  const params = new URLSearchParams({ [type]: value });
+  return `/blog/?${params.toString()}`;
+}
+
+export function isAllPostsCategory(category: string | undefined): boolean {
+  return !category || category === ALL_POSTS_CATEGORY;
+}
+
+export function getPostCategories(posts: PostMeta[]): string[] {
+  return [ALL_POSTS_CATEGORY, ...Array.from(new Set(posts.map(post => post.category.text)))];
+}
+
+export function getPostTags(posts: PostMeta[]): string[] {
+  return Array.from(new Set(posts.flatMap(post => post.tags)));
 }
 
 /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,32 @@
+type LogLevel = 'error' | 'warn';
+
+function formatLogDetail(detail: unknown): string {
+  if (!detail) {
+    return '';
+  }
+
+  if (detail instanceof Error) {
+    return detail.message;
+  }
+
+  if (typeof detail === 'string') {
+    return detail;
+  }
+
+  return 'Unknown error';
+}
+
+function writeLog(level: LogLevel, context: string, detail?: unknown) {
+  const message = formatLogDetail(detail);
+  const suffix = process.env.NODE_ENV !== 'production' && message ? `: ${message}` : '';
+
+  console[level](`[${context}]${suffix}`);
+}
+
+export function logError(context: string, detail?: unknown) {
+  writeLog('error', context, detail);
+}
+
+export function logWarn(context: string, detail?: unknown) {
+  writeLog('warn', context, detail);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,26 +1,14 @@
 type LogLevel = 'error' | 'warn';
 
-function formatLogDetail(detail: unknown): string {
-  if (!detail) {
-    return '';
-  }
-
-  if (detail instanceof Error) {
-    return detail.message;
-  }
-
-  if (typeof detail === 'string') {
-    return detail;
-  }
-
-  return 'Unknown error';
-}
-
 function writeLog(level: LogLevel, context: string, detail?: unknown) {
-  const message = formatLogDetail(detail);
-  const suffix = process.env.NODE_ENV !== 'production' && message ? `: ${message}` : '';
+  const message = `[${context}]`;
 
-  console[level](`[${context}]${suffix}`);
+  if (process.env.NODE_ENV === 'production' || typeof detail === 'undefined') {
+    console[level](message);
+    return;
+  }
+
+  console[level](message, detail);
 }
 
 export function logError(context: string, detail?: unknown) {

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -102,8 +102,8 @@ function normalizeSearchText(value: string): string {
 }
 
 function levenshteinDistance(source: string, target: string): number {
-  const previous = Array.from({ length: target.length + 1 }, (_, index) => index);
-  const current = Array.from({ length: target.length + 1 }, () => 0);
+  let previous = Array.from({ length: target.length + 1 }, (_, index) => index);
+  let current = Array.from({ length: target.length + 1 }, () => 0);
 
   for (let sourceIndex = 1; sourceIndex <= source.length; sourceIndex += 1) {
     current[0] = sourceIndex;
@@ -117,9 +117,7 @@ function levenshteinDistance(source: string, target: string): number {
       );
     }
 
-    for (let index = 0; index < previous.length; index += 1) {
-      previous[index] = current[index];
-    }
+    [previous, current] = [current, previous];
   }
 
   return previous[target.length];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     // Unit 테스트만 유지
     name: 'unit',
     environment: 'jsdom',
+    pool: 'threads',
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['src/**/*.stories.test.{ts,tsx}'],


### PR DESCRIPTION
## Summary
- centralize blog URL/filter helpers and post filter derivation without changing visible routing behavior
- remove duplicated sort-control rendering and avoid mutating RecentPosts props during date sorting
- optimize token Levenshtein matching by swapping DP rows instead of copying rows
- sanitize JSON-LD script serialization and route production logs through a small logger
- strengthen check-repo governance for structural smells, logging hygiene, and behavior-preserving URL shape

## Verification
- KNOWLEDGE_BASE_PATH=.cache/knowledge-base bun run verify
- pre-push next build

Notes:
- no visual/design behavior changes intended
- auto-merge intentionally not enabled