### PR TITLE
Avoid markdown URL false positives in checks

### DIFF
--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -28,7 +28,6 @@ const FORBIDDEN_CATEGORY_NAMES = new Set([
   'source',
   'youtube',
 ]);
-const RELATIVE_MARKDOWN_LINK_PATTERN = /\.mdx?(#.*)?$/i;
 const LOCAL_ASSET_PATTERN = /^(\.{1,2}\/|assets\/)/i;
 const PUBLIC_CONTENT_ASSET_PATTERN = /^\/content\/posts\/[^/]+\/assets\/[^?#]+$/;
 const CONTENT_HASHED_ASSET_PATTERN = /\.[a-f0-9]{12}\.[^/.?#]+$/i;
@@ -45,6 +44,19 @@ interface ContentLinkIndexData {
 
 function readJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+function isExternalUrl(value: string): boolean {
+  return /^(https?:)?\/\//i.test(value) || /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isMarkdownFileHref(value: string): boolean {
+  if (!value || value.startsWith('#') || isExternalUrl(value)) {
+    return false;
+  }
+
+  const [pathname] = value.split('#');
+  return /\.mdx?$/i.test(pathname);
 }
 
 function normalizeMachineDate(value: unknown): string {
@@ -112,7 +124,7 @@ function walkMarkdownFiles(root: string): string[] {
 }
 
 function publicFileExists(publicPath: string): boolean {
-  if (/^(https?:)?\/\//i.test(publicPath) || /^[a-z][a-z0-9+.-]*:/i.test(publicPath)) {
+  if (isExternalUrl(publicPath)) {
     return true;
   }
 
@@ -121,7 +133,7 @@ function publicFileExists(publicPath: string): boolean {
 }
 
 function publicPathToFilePath(publicPath: string): string | null {
-  if (/^(https?:)?\/\//i.test(publicPath) || /^[a-z][a-z0-9+.-]*:/i.test(publicPath)) {
+  if (isExternalUrl(publicPath)) {
     return null;
   }
 
@@ -167,7 +179,7 @@ function checkMarkdownLinksAndImages(filePath: string, content: string, errors: 
   visit(tree, ['link', 'image'], node => {
     if (node.type === 'link') {
       const link = node as Link;
-      if (RELATIVE_MARKDOWN_LINK_PATTERN.test(link.url)) {
+      if (isMarkdownFileHref(link.url)) {
         errors.push(`${relativeFile}: leftover Markdown file link was not rewritten: ${link.url}`);
       }
       return;

--- a/scripts/check-links.ts
+++ b/scripts/check-links.ts
@@ -26,6 +26,19 @@ import {
 
 const WIKI_LINK_PATTERN = /\[\[([^\]|#]+(?:#[^\]|]+)?)(?:\|([^\]]+))?\]\]/g;
 
+function isExternalUrl(value: string): boolean {
+  return /^(https?:)?\/\//i.test(value) || /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isMarkdownFileHref(value: string): boolean {
+  if (!value || value.startsWith('#') || isExternalUrl(value)) {
+    return false;
+  }
+
+  const [pathname] = value.split('#');
+  return /\.mdx?$/i.test(pathname);
+}
+
 function readExportedPosts(contentRoot: string) {
   if (!fs.existsSync(contentRoot)) {
     return [];
@@ -39,7 +52,7 @@ function readExportedPosts(contentRoot: string) {
 }
 
 function checkImagePath(url: string): boolean {
-  if (/^(https?:)?\/\//i.test(url) || /^[a-z][a-z0-9+.-]*:/i.test(url)) {
+  if (isExternalUrl(url)) {
     return true;
   }
 
@@ -83,7 +96,7 @@ function checkExportedPost(filePath: string, index: ContentIndex): ContentDiagno
   visit(tree, ['link', 'image'], node => {
     if (node.type === 'link') {
       const link = node as Link;
-      if (/\.mdx?(#.*)?$/i.test(link.url)) {
+      if (isMarkdownFileHref(link.url)) {
         diagnostics.push(
           diagnostic(
             'error',
@@ -100,7 +113,7 @@ function checkExportedPost(filePath: string, index: ContentIndex): ContentDiagno
         sourceNote,
         index,
       );
-      if (resolution.warning && /\.mdx?(#.*)?$/i.test(link.url)) {
+      if (resolution.warning && isMarkdownFileHref(link.url)) {
         diagnostics.push(
           diagnostic('warning', 'LINK_DEGRADED_TO_TEXT', resolution.warning, relativeFile),
         );

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -31,6 +31,25 @@ function publicPathToFilePath(publicPath: string): string | null {
   return publicPath.startsWith('/') ? path.join(PROJECT_ROOT, 'public', publicPath) : null;
 }
 
+function isExternalUrl(value: string): boolean {
+  return /^(https?:)?\/\//i.test(value) || /^[a-z][a-z0-9+.-]*:/i.test(value);
+}
+
+function isMarkdownFileHref(value: string): boolean {
+  if (!value || value.startsWith('#') || isExternalUrl(value)) {
+    return false;
+  }
+
+  const [pathname] = value.split('#');
+  return /\.mdx?$/i.test(pathname);
+}
+
+function renderedMarkdownFileHrefs(html: string): string[] {
+  return [...html.matchAll(/"href":"([^"]+)"/g), ...html.matchAll(/\bhref="([^"]+)"/g)]
+    .map(match => match[1])
+    .filter(isMarkdownFileHref);
+}
+
 function createBlogFilterHref(type: 'category' | 'tags', value: string): string {
   const params = new URLSearchParams({ [type]: value });
   return `/blog/?${params.toString()}`;
@@ -200,11 +219,18 @@ function checkRenderedPost(post: PostMeta, errors: string[]) {
     }
   }
 
-  const forbiddenMarkers = ['katex-error', '\\mathbb{E}\\_', '\\big\\[', '.md"'];
+  const forbiddenMarkers = ['katex-error', '\\mathbb{E}\\_', '\\big\\['];
   for (const marker of forbiddenMarkers) {
     if (html.includes(marker)) {
       errors.push(`Post "${post.slug}" contains forbidden rendered marker "${marker}".`);
     }
+  }
+
+  const markdownFileHrefs = renderedMarkdownFileHrefs(html);
+  if (markdownFileHrefs.length > 0) {
+    errors.push(
+      `Post "${post.slug}" rendered Markdown file hrefs: ${markdownFileHrefs.join(', ')}`,
+    );
   }
 
   if (/annotation encoding="application\/x-tex">[^<]*[’‘′″‴]/.test(html)) {


### PR DESCRIPTION
## Summary
- Treat external URLs like https://obsidian.md as external links before checking for leftover .md/.mdx file links
- Apply the same markdown-file href predicate to content quality, link, and smoke checks
- Keep smoke validation focused on rendered href values instead of raw .md text anywhere in output

## Verification
- bun run check-content
- bun run check-links
- bun run smoke:out
- pre-commit: types:check and unit tests
- pre-push: content sync and build