### PR TITLE
Use post titles for reference wikilinks

### DIFF
--- a/src/__tests__/libs/content/exporter.test.ts
+++ b/src/__tests__/libs/content/exporter.test.ts
@@ -77,7 +77,8 @@ describe('content exporter', () => {
     expect(result.markdown).not.toContain(
       '\\*[PostgreSQL 자체 Git 저장소](https://git.postgresql.org/git/postgresql.git)\\*를',
     );
-    expect(result.markdown).toMatch(/[*-] \[\[second-note\]\]/);
+    expect(result.markdown).toMatch(/[*-] \[Second Note\]\(\/blog\/second-note\)/);
+    expect(result.markdown).not.toMatch(/[*-] \[\[second-note\]\]/);
     expect(result.markdown).not.toMatch(/[*-] \[\[youtube-source\]\]/);
     expect(result.markdown).not.toContain('../sources/private-source.md');
     expect(result.markdown).not.toContain('./second-note.md');

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -19,6 +19,7 @@ import { normalizeMarkdownImageSizeSyntax } from './imageDimensions';
 import { parseInlineMarkdownChildren } from './inlineMarkdown';
 import { resolveMarkdownLink } from './linkResolver';
 import { normalizeKatexMathTree } from './math';
+import { slugifyHeading } from './slug';
 import type {
   ContentDiagnostic,
   ContentIndex,
@@ -242,7 +243,41 @@ function wikiTargetPage(target: string): string {
   return target.split('#')[0].trim();
 }
 
-function transformReferenceSourceWikilinks(tree: Root, index: ContentIndex) {
+function wikiTargetAnchor(target: string): string | undefined {
+  return target.split('#')[1]?.trim() || undefined;
+}
+
+function withAnchor(href: string, anchor?: string): string {
+  return anchor ? `${href}#${slugifyHeading(anchor)}` : href;
+}
+
+function resolveReferenceWikiLink(
+  parsed: ParsedWikiLink,
+  index: ContentIndex,
+): { label: string; href: string } | null {
+  const targetPage = wikiTargetPage(parsed.target);
+  const publishedNote = index.publishedByBasename.get(targetPage);
+
+  if (publishedNote) {
+    return {
+      label: parsed.alias || publishedNote.frontmatter.title || publishedNote.stem,
+      href: withAnchor(publishedNote.href, wikiTargetAnchor(parsed.target)),
+    };
+  }
+
+  const sourceUrl = index.sourceUrlByBasename.get(targetPage);
+
+  if (sourceUrl) {
+    return {
+      label: parsed.alias || index.sourceLabelByBasename.get(targetPage) || parsed.target,
+      href: sourceUrl,
+    };
+  }
+
+  return null;
+}
+
+function transformReferenceWikilinks(tree: Root, index: ContentIndex) {
   const referenceChildren = collectReferenceSectionChildren(tree);
 
   if (referenceChildren.size === 0) {
@@ -265,9 +300,9 @@ function transformReferenceSourceWikilinks(tree: Root, index: ContentIndex) {
         const rawValue = match[1];
         const start = match.index ?? 0;
         const parsed = parseWikiLink(rawValue);
-        const sourceUrl = index.sourceUrlByBasename.get(wikiTargetPage(parsed.target));
+        const resolution = resolveReferenceWikiLink(parsed, index);
 
-        if (!sourceUrl) {
+        if (!resolution) {
           continue;
         }
 
@@ -275,11 +310,7 @@ function transformReferenceSourceWikilinks(tree: Root, index: ContentIndex) {
           replacements.push(textNode(text.value.slice(cursor, start)));
         }
 
-        const label =
-          parsed.alias ||
-          index.sourceLabelByBasename.get(wikiTargetPage(parsed.target)) ||
-          parsed.target;
-        replacements.push(markdownLinkNode(label, sourceUrl));
+        replacements.push(markdownLinkNode(resolution.label, resolution.href));
         cursor = start + match[0].length;
         changed = true;
       }
@@ -363,7 +394,7 @@ export function transformMarkdownForExport(
   let cover = note.frontmatter.cover;
 
   normalizeKatexMathTree(tree);
-  transformReferenceSourceWikilinks(tree, index);
+  transformReferenceWikilinks(tree, index);
   removeDuplicateReferenceOriginalLinks(tree);
 
   if (cover && isLocalAssetUrl(cover)) {


### PR DESCRIPTION
## Summary
- Rewrite reference-section wikilinks for published posts during export
- Use the target post frontmatter title as the reference card label when no alias is provided
- Preserve existing source_url title handling and aliases

## Verification
- bun run verify
- pre-commit: types:check and unit tests
- pre-push: content sync and build