### PR TITLE
Use shadow-only reference card boundaries

### DIFF
--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -505,6 +505,13 @@ function readCssRules(css: string, selector: string): string[] {
   );
 }
 
+function normalizeCssValue(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*/g, ', ')
+    .trim();
+}
+
 function requireCssDeclarations(
   css: string,
   relativeFile: string,
@@ -519,8 +526,14 @@ function requireCssDeclarations(
   }
 
   for (const [property, value] of declarations) {
-    const declarationPattern = new RegExp(`${property}:\\s*${escapeRegExp(value)};`);
-    if (!rules.some(rule => declarationPattern.test(rule))) {
+    const expectedValue = normalizeCssValue(value);
+    const declarationPattern = new RegExp(`${property}:\\s*([^;]+);`);
+    if (
+      !rules.some(rule => {
+        const match = rule.match(declarationPattern);
+        return match ? normalizeCssValue(match[1]) === expectedValue : false;
+      })
+    ) {
       errors.push(`${relativeFile}: "${selector}" must keep "${property}: ${value};".`);
     }
   }
@@ -757,10 +770,10 @@ function checkMarkdownCss(errors: string[]) {
     ['width', '100%'],
     ['padding', '0.85rem 0.75rem'],
     ['gap', '0.75rem'],
-    ['border', '0.0625rem solid var(--fg-color-1)'],
+    ['border', '0'],
     ['border-radius', '0.375rem'],
     ['background', 'var(--bg-color-1)'],
-    ['box-shadow', '0 0.125rem 0.375rem var(--fg-color-0)'],
+    ['box-shadow', '0 0 0 0.0625rem var(--fg-color-1), 0 0.125rem 0.5rem var(--fg-color-0)'],
     ['cursor', 'pointer'],
     ['text-decoration', 'none'],
   ]);

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -390,8 +390,11 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
   if (
     !referenceCardRule.includes('display:flex') ||
     !referenceCardRule.includes('padding:.85rem .75rem') ||
+    !referenceCardRule.includes('border:0') ||
     !referenceCardRule.includes('background:var(--bg-color-1)') ||
-    !referenceCardRule.includes('box-shadow:0 .125rem .375rem var(--fg-color-0)') ||
+    !referenceCardRule.includes(
+      'box-shadow:0 0 0 .0625rem var(--fg-color-1), 0 .125rem .5rem var(--fg-color-0)',
+    ) ||
     !referenceCardRule.includes('cursor:pointer')
   ) {
     errors.push('Built Markdown CSS must include clickable compact reference card styling.');

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -563,24 +563,27 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: space-between;
-  border: 0.0625rem solid var(--fg-color-1);
+  border: 0;
   border-radius: 0.375rem;
   background: var(--bg-color-1);
-  box-shadow: 0 0.125rem 0.375rem var(--fg-color-0);
+  box-shadow:
+    0 0 0 0.0625rem var(--fg-color-1),
+    0 0.125rem 0.5rem var(--fg-color-0);
   color: var(--fg-color);
   cursor: pointer;
   text-decoration: none;
   opacity: 1;
   transition:
-    border-color 100ms ease-in,
     background-color 100ms ease-in,
+    box-shadow 100ms ease-in,
     opacity 100ms ease-in;
 }
 
 .post-body .reference-card:hover {
-  border-color: var(--fg-color-2);
   background: var(--bg-color-0);
-  box-shadow: 0 0.1875rem 0.625rem var(--fg-color-1);
+  box-shadow:
+    0 0 0 0.0625rem var(--fg-color-2),
+    0 0.1875rem 0.75rem var(--fg-color-1);
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- Remove the border from compact reference cards
- Use layered box-shadow for the visible boundary and hover state
- Update CSS quality and smoke checks to enforce the shadow-only boundary

## Verification
- bun run verify
- bun run check-content
- bun run smoke:out
- pre-commit: types:check and unit tests
- pre-push: content sync and build