### PR TITLE
Use added date in blog URLs

### DIFF
--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -11,6 +11,7 @@ import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 
 import { resolveCategoryRgb } from '../src/libs/content/category.js';
+import { createDatedPostSlug } from '../src/libs/content/slug.js';
 import type { PostMeta } from '../src/types/blog.js';
 import {
   PROJECT_ROOT,
@@ -39,6 +40,7 @@ interface MathNode {
 }
 
 interface ContentLinkIndexData {
+  published?: Record<string, string>;
   sources?: Record<string, string>;
 }
 
@@ -148,6 +150,51 @@ function hasContentHashInAssetName(value: string): boolean {
   return CONTENT_HASHED_ASSET_PATTERN.test(value);
 }
 
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseInternalBlogHref(value: string): { slug: string; hash: string } | null {
+  let pathWithHash = value;
+
+  if (!value.startsWith('/')) {
+    const match = value.match(/^https?:\/\/(?:www\.)?r3gardless\.dev(\/.*)?$/i);
+    if (!match) {
+      return null;
+    }
+
+    pathWithHash = match[1] || '/';
+  }
+
+  const hashIndex = pathWithHash.indexOf('#');
+  const pathname = hashIndex === -1 ? pathWithHash : pathWithHash.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : pathWithHash.slice(hashIndex);
+  const match = pathname.match(/^\/blog\/([^/?]+)\/?$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    slug: match[1],
+    hash,
+  };
+}
+
+function expectedInternalBlogHref(value: string, linkIndex: ContentLinkIndexData): string | null {
+  const parsed = parseInternalBlogHref(value);
+  if (!parsed) {
+    return null;
+  }
+
+  const key = safeDecodeURIComponent(parsed.slug);
+  const expectedHref = linkIndex.published?.[parsed.slug] ?? linkIndex.published?.[key];
+  return expectedHref ? `${expectedHref}${parsed.hash}` : null;
+}
+
 function checkMarkdownMath(filePath: string, content: string, errors: string[]) {
   const tree = unified().use(remarkParse).use(remarkGfm).use(remarkMath).parse(content) as Root;
   const relativeFile = path.relative(PROJECT_ROOT, filePath);
@@ -164,7 +211,12 @@ function checkMarkdownMath(filePath: string, content: string, errors: string[]) 
   });
 }
 
-function checkMarkdownLinksAndImages(filePath: string, content: string, errors: string[]) {
+function checkMarkdownLinksAndImages(
+  filePath: string,
+  content: string,
+  errors: string[],
+  linkIndex: ContentLinkIndexData,
+) {
   const tree = unified().use(remarkParse).use(remarkGfm).use(remarkMath).parse(content) as Root;
   const relativeFile = path.relative(PROJECT_ROOT, filePath);
 
@@ -181,6 +233,13 @@ function checkMarkdownLinksAndImages(filePath: string, content: string, errors: 
       const link = node as Link;
       if (isMarkdownFileHref(link.url)) {
         errors.push(`${relativeFile}: leftover Markdown file link was not rewritten: ${link.url}`);
+      }
+
+      const expectedHref = expectedInternalBlogHref(link.url, linkIndex);
+      if (expectedHref && link.url !== expectedHref) {
+        errors.push(
+          `${relativeFile}: internal blog link "${link.url}" must be rewritten to "${expectedHref}".`,
+        );
       }
       return;
     }
@@ -454,6 +513,17 @@ function checkPostMetadata(postFiles: string[], errors: string[], linkIndex: Con
       );
     }
 
+    const expectedSlug = createDatedPostSlug(
+      slug,
+      typeof frontmatter.slug === 'string' ? frontmatter.slug : undefined,
+      normalizeMachineDate(frontmatter.added ?? frontmatter.published_at),
+    );
+    if (slug !== expectedSlug) {
+      errors.push(
+        `${relativeFile}: blog slug must use /blog/<added>-<slug>, expected "${expectedSlug}".`,
+      );
+    }
+
     const expectedPublishedAt = normalizeMachineDate(frontmatter.published_at ?? frontmatter.added);
     const expectedUpdatedAt = normalizeMachineDate(
       frontmatter.updated ?? frontmatter.published_at ?? frontmatter.added,
@@ -476,7 +546,7 @@ function checkPostMetadata(postFiles: string[], errors: string[], linkIndex: Con
     }
 
     checkMarkdownMath(filePath, parsed.content, errors);
-    checkMarkdownLinksAndImages(filePath, parsed.content, errors);
+    checkMarkdownLinksAndImages(filePath, parsed.content, errors, linkIndex);
     checkReferenceSourceWikilinks(filePath, parsed.content, errors, linkIndex);
   }
 
@@ -773,9 +843,13 @@ function checkMarkdownCss(errors: string[]) {
     ['border', '0'],
     ['border-radius', '0.375rem'],
     ['background', 'var(--bg-color-1)'],
-    ['box-shadow', '0 0 0 0.0625rem var(--fg-color-1), 0 0.125rem 0.5rem var(--fg-color-0)'],
+    ['box-shadow', '0 0.125rem 0.5rem var(--fg-color-0)'],
     ['cursor', 'pointer'],
     ['text-decoration', 'none'],
+  ]);
+
+  requireCssDeclarations(css, relativeFile, errors, '.post-body .reference-card:hover', [
+    ['box-shadow', '0 0 0 0.0625rem var(--fg-color-2), 0 0.1875rem 0.75rem var(--fg-color-1)'],
   ]);
 
   requireCssDeclarations(css, relativeFile, errors, '.post-body .reference-card-title', [

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -387,17 +387,24 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
   }
 
   const referenceCardRule = readBuiltCssRule(css, '.post-body .reference-card');
+  const referenceCardHoverRule = readBuiltCssRule(css, '.post-body .reference-card:hover');
   if (
     !referenceCardRule.includes('display:flex') ||
     !referenceCardRule.includes('padding:.85rem .75rem') ||
     !referenceCardRule.includes('border:0') ||
     !referenceCardRule.includes('background:var(--bg-color-1)') ||
-    !referenceCardRule.includes(
-      'box-shadow:0 0 0 .0625rem var(--fg-color-1), 0 .125rem .5rem var(--fg-color-0)',
-    ) ||
+    !referenceCardRule.includes('box-shadow:0 .125rem .5rem var(--fg-color-0)') ||
     !referenceCardRule.includes('cursor:pointer')
   ) {
     errors.push('Built Markdown CSS must include clickable compact reference card styling.');
+  }
+
+  if (
+    !referenceCardHoverRule.includes(
+      'box-shadow:0 0 0 .0625rem var(--fg-color-2), 0 .1875rem .75rem var(--fg-color-1)',
+    )
+  ) {
+    errors.push('Built Markdown CSS must show compact reference card boundary on hover.');
   }
 
   if (

--- a/src/__tests__/libs/content/content.test.ts
+++ b/src/__tests__/libs/content/content.test.ts
@@ -8,6 +8,7 @@ import {
   resolveCategoryColor,
   resolveCategoryForegroundRgb,
   resolveCategoryRgb,
+  createDatedPostSlug,
   resolveMarkdownLink,
   resolveWikiLink,
   slugifyHeading,
@@ -22,7 +23,10 @@ describe('content loader', () => {
 
     expect(index.diagnostics).toEqual([]);
     expect(index.notes.length).toBeGreaterThan(0);
-    expect(index.publishedNotes.map(note => note.slug)).toEqual(['published-note', 'second-note']);
+    expect(index.publishedNotes.map(note => note.slug)).toEqual([
+      '2026-06-21-published-note',
+      '2026-06-20-second-note',
+    ]);
     expect(index.publishedNotes.map(note => note.frontmatter.title)).toEqual([
       'Published Note',
       'Second Note',
@@ -45,8 +49,12 @@ describe('content loader', () => {
   it('builds published and source_url maps by basename and title', () => {
     const index = buildContentIndex(fixtureKbRoot);
 
-    expect(index.publishedByBasename.get('published-note')?.href).toBe('/blog/published-note');
-    expect(index.publishedByBasename.get('Published Note')?.href).toBe('/blog/published-note');
+    expect(index.publishedByBasename.get('published-note')?.href).toBe(
+      '/blog/2026-06-21-published-note',
+    );
+    expect(index.publishedByBasename.get('Published Note')?.href).toBe(
+      '/blog/2026-06-21-published-note',
+    );
     expect(index.sourceUrlByBasename.get('youtube-source')).toBe(
       'https://www.youtube.com/watch?v=fixture',
     );
@@ -59,6 +67,12 @@ describe('content loader', () => {
 
   it('normalizes post and heading slugs without dropping Korean text', () => {
     expect(slugifyPost('송희구. 투자 원칙')).toBe('송희구-투자-원칙');
+    expect(createDatedPostSlug('published-note', undefined, '2026-06-21')).toBe(
+      '2026-06-21-published-note',
+    );
+    expect(createDatedPostSlug('2025-01-01-published-note', undefined, '2026-06-21')).toBe(
+      '2026-06-21-published-note',
+    );
     expect(slugifyHeading('Details Section')).toBe('details-section');
   });
 
@@ -92,14 +106,14 @@ describe('content link resolver', () => {
       kind: 'internal',
       label: 'second-note',
       target: 'second-note',
-      href: '/blog/second-note',
+      href: '/blog/2026-06-20-second-note',
     });
 
     expect(resolveWikiLink('second-note#Details Section', 'alias', index)).toEqual({
       kind: 'internal',
       label: 'alias',
       target: 'second-note#Details Section',
-      href: '/blog/second-note#details-section',
+      href: '/blog/2026-06-20-second-note#details-section',
     });
   });
 
@@ -141,7 +155,35 @@ describe('content link resolver', () => {
       kind: 'internal',
       label: 'second',
       target: 'second-note',
-      href: '/blog/second-note',
+      href: '/blog/2026-06-20-second-note',
+    });
+    expect(resolveMarkdownLink('/blog/second-note', 'old internal', note!, index)).toEqual({
+      kind: 'internal',
+      label: 'old internal',
+      target: '/blog/second-note',
+      href: '/blog/2026-06-20-second-note',
+    });
+    expect(
+      resolveMarkdownLink(
+        'https://r3gardless.dev/blog/second-note#details-section',
+        'old absolute',
+        note!,
+        index,
+      ),
+    ).toEqual({
+      kind: 'internal',
+      label: 'old absolute',
+      target: 'https://r3gardless.dev/blog/second-note#details-section',
+      href: '/blog/2026-06-20-second-note#details-section',
+    });
+    expect(
+      resolveMarkdownLink('https://example.com/blog/second-note', 'external', note!, index),
+    ).toEqual({
+      kind: 'external',
+      label: 'external',
+      target: 'https://example.com/blog/second-note',
+      href: 'https://example.com/blog/second-note',
+      external: true,
     });
     expect(resolveMarkdownLink('../sources/youtube-source.md', 'source', note!, index)).toEqual({
       kind: 'external',

--- a/src/__tests__/libs/content/exporter.test.ts
+++ b/src/__tests__/libs/content/exporter.test.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildContentIndex, exportPublishedPost, transformMarkdownForExport } from '@/libs/content';
 
 const fixtureKbRoot = path.join(process.cwd(), 'tests/fixtures/kb/KNOWELDGE_BASE');
+const publishedSlug = '2026-06-21-published-note';
+const secondSlug = '2026-06-20-second-note';
 
 let tempRoot: string;
 
@@ -42,7 +44,7 @@ describe('content exporter', () => {
       }),
     ]);
     expect(result.markdown).toMatch(
-      /cover: \/content\/posts\/published-note\/assets\/cover\.[a-f0-9]{12}\.svg/,
+      /cover: \/content\/posts\/2026-06-21-published-note\/assets\/cover\.[a-f0-9]{12}\.svg/,
     );
     expect(result.markdown).toContain('[[second-note|another note]]');
     expect(result.markdown).toContain('> [!TIP]');
@@ -52,7 +54,9 @@ describe('content exporter', () => {
     expect(result.markdown).not.toContain('\\mathbb{E}\\_X');
     expect(result.markdown).not.toContain('\\big\\[');
     expect(result.markdown).toContain('[[youtube-source|the original source]]');
-    expect(result.markdown).toContain('[second](/blog/second-note)');
+    expect(result.markdown).toContain(`[second](/blog/${secondSlug})`);
+    expect(result.markdown).toContain(`[internal old URL](/blog/${secondSlug})`);
+    expect(result.markdown).toContain(`[absolute old URL](/blog/${secondSlug}#details-section)`);
     expect(result.markdown).toContain('[source](https://www.youtube.com/watch?v=fixture)');
     expect(result.markdown).toContain('[YouTube Source](https://www.youtube.com/watch?v=fixture)');
     expect(result.markdown).not.toContain(
@@ -77,29 +81,31 @@ describe('content exporter', () => {
     expect(result.markdown).not.toContain(
       '\\*[PostgreSQL 자체 Git 저장소](https://git.postgresql.org/git/postgresql.git)\\*를',
     );
-    expect(result.markdown).toMatch(/[*-] \[Second Note\]\(\/blog\/second-note\)/);
+    expect(result.markdown).toMatch(
+      new RegExp(String.raw`[*-] \[Second Note\]\(/blog/${secondSlug}\)`),
+    );
     expect(result.markdown).not.toMatch(/[*-] \[\[second-note\]\]/);
     expect(result.markdown).not.toMatch(/[*-] \[\[youtube-source\]\]/);
     expect(result.markdown).not.toContain('../sources/private-source.md');
     expect(result.markdown).not.toContain('./second-note.md');
     expect(result.markdown).toMatch(
-      /!\[Fixture image\]\(\/content\/posts\/published-note\/assets\/diagram\.[a-f0-9]{12}\.svg\)/,
+      /!\[Fixture image\]\(\/content\/posts\/2026-06-21-published-note\/assets\/diagram\.[a-f0-9]{12}\.svg\)/,
     );
     expect(result.markdown).toMatch(
-      /!\[Sized fixture\]\(\/content\/posts\/published-note\/assets\/diagram\.[a-f0-9]{12}\.svg\)\{width=320 height=180\}/,
+      /!\[Sized fixture\]\(\/content\/posts\/2026-06-21-published-note\/assets\/diagram\.[a-f0-9]{12}\.svg\)\{width=320 height=180\}/,
     );
     expect(
       fs
-        .readdirSync(path.join(tempRoot, 'public/content/posts/published-note/assets'))
+        .readdirSync(path.join(tempRoot, 'public/content/posts', publishedSlug, 'assets'))
         .some(fileName => /^diagram\.[a-f0-9]{12}\.svg$/.test(fileName)),
     ).toBe(true);
     expect(
       fs
-        .readdirSync(path.join(tempRoot, 'public/content/posts/published-note/assets'))
+        .readdirSync(path.join(tempRoot, 'public/content/posts', publishedSlug, 'assets'))
         .some(fileName => /^cover\.[a-f0-9]{12}\.svg$/.test(fileName)),
     ).toBe(true);
 
-    const exportedAssetsDir = path.join(tempRoot, 'public/content/posts/published-note/assets');
+    const exportedAssetsDir = path.join(tempRoot, 'public/content/posts', publishedSlug, 'assets');
     const exportedCover = fs
       .readdirSync(exportedAssetsDir)
       .find(fileName => /^cover\.[a-f0-9]{12}\.svg$/.test(fileName));
@@ -125,8 +131,8 @@ describe('content exporter', () => {
       exportPublishedPost(note, index, paths);
     }
 
-    expect(fs.existsSync(path.join(paths.contentRoot, 'published-note/index.md'))).toBe(true);
-    expect(fs.existsSync(path.join(paths.contentRoot, 'second-note/index.md'))).toBe(true);
+    expect(fs.existsSync(path.join(paths.contentRoot, `${publishedSlug}/index.md`))).toBe(true);
+    expect(fs.existsSync(path.join(paths.contentRoot, `${secondSlug}/index.md`))).toBe(true);
     expect(fs.existsSync(path.join(paths.contentRoot, 'draft-note/index.md'))).toBe(false);
     expect(fs.existsSync(path.join(paths.contentRoot, 'youtube-source/index.md'))).toBe(false);
   });

--- a/src/__tests__/libs/content/postMeta.test.ts
+++ b/src/__tests__/libs/content/postMeta.test.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { buildContentIndex, exportPublishedPost, readPostMetaFromContent } from '@/libs/content';
 
 const fixtureKbRoot = path.join(process.cwd(), 'tests/fixtures/kb/KNOWELDGE_BASE');
+const publishedSlug = '2026-06-21-published-note';
+const secondSlug = '2026-06-20-second-note';
 
 let tempRoot: string;
 
@@ -36,7 +38,7 @@ describe('post metadata from exported content', () => {
 
     expect(posts).toHaveLength(2);
     expect(posts[0]).toMatchObject({
-      pageId: 'published-note',
+      pageId: publishedSlug,
       id: 2,
       title: 'Published Note',
       description: 'A published fixture note.',
@@ -47,20 +49,20 @@ describe('post metadata from exported content', () => {
         foregroundRgb: expect.stringMatching(/^\d+ \d+ \d+$/),
       },
       tags: ['blog', 'fixture'],
-      slug: 'published-note',
-      encodedSlug: 'published-note',
+      slug: publishedSlug,
+      encodedSlug: publishedSlug,
       cover: expect.stringMatching(
-        /^\/content\/posts\/published-note\/assets\/cover\.[a-f0-9]{12}\.svg$/,
+        /^\/content\/posts\/2026-06-21-published-note\/assets\/cover\.[a-f0-9]{12}\.svg$/,
       ),
     });
     expect(posts[0].createdAt).toBe('Jun 21, 2026');
     expect(posts[0].publishedAt).toBe('2026-06-21');
     expect(posts[0].updatedAt).toBe('2026-06-21');
     expect(posts[1]).toMatchObject({
-      pageId: 'second-note',
+      pageId: secondSlug,
       id: 1,
       title: 'Second Note',
-      slug: 'second-note',
+      slug: secondSlug,
     });
   });
 });

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -5,7 +5,7 @@ import { extractTableOfContentsFromMarkdown, renderMarkdownToReact } from '@/lib
 
 const linkMaps = {
   published: {
-    'second-note': '/blog/second-note',
+    'second-note': '/blog/2026-06-20-second-note',
   },
   sources: {
     'youtube-source': 'https://www.youtube.com/watch?v=fixture',
@@ -59,7 +59,7 @@ flowchart TD
     expect(screen.getByRole('heading', { name: 'Render Fixture' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'the second note' })).toHaveAttribute(
       'href',
-      '/blog/second-note',
+      '/blog/2026-06-20-second-note',
     );
     expect(screen.getByRole('link', { name: 'the source' })).toHaveAttribute(
       'href',
@@ -356,7 +356,7 @@ Normal link to [Product Quantization](https://doi.org/10.1109/TPAMI.2010.57).
 # Sources
 
 - [Product Quantization for Nearest Neighbor Search](https://doi.org/10.1109/TPAMI.2010.57)
-- [Internal Note](/blog/second-note)
+- [Internal Note](/blog/2026-06-20-second-note)
 `);
 
     const { container } = render(<>{content}</>);
@@ -369,7 +369,7 @@ Normal link to [Product Quantization](https://doi.org/10.1109/TPAMI.2010.57).
     expect(referenceCards[0]).toHaveAttribute('target', '_blank');
     expect(referenceCards[0]).toHaveTextContent('Product Quantization for Nearest Neighbor Search');
     expect(referenceCards[0]).toHaveTextContent('doi.org');
-    expect(referenceCards[1]).toHaveAttribute('href', '/blog/second-note');
+    expect(referenceCards[1]).toHaveAttribute('href', '/blog/2026-06-20-second-note');
     expect(referenceCards[1]).toHaveTextContent('r3gardless.dev');
     expect(container.querySelector('.reference-card-list')).toBeInTheDocument();
     expect(container.querySelectorAll('.reference-card-list-item')).toHaveLength(2);

--- a/src/__tests__/utils/blog.test.ts
+++ b/src/__tests__/utils/blog.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../utils/blog';
 
 const basePost = {
-  pageId: 'published-note',
+  pageId: '2026-06-21-published-note',
   id: 1,
   title: 'Published Note',
   description: 'Description',
@@ -27,8 +27,8 @@ const basePost = {
     color: 'gray',
   },
   tags: ['kb'],
-  slug: 'published-note',
-  encodedSlug: 'published-note',
+  slug: '2026-06-21-published-note',
+  encodedSlug: '2026-06-21-published-note',
 } satisfies PostMeta;
 
 describe('Blog Utils', () => {
@@ -38,7 +38,7 @@ describe('Blog Utils', () => {
 
       expect(result).toMatchObject({
         title: 'Published Note',
-        href: '/blog/published-note',
+        href: '/blog/2026-06-21-published-note',
       });
     });
 
@@ -46,7 +46,7 @@ describe('Blog Utils', () => {
       const result = convertPostsForRendering([basePost]);
 
       expect(result).toHaveLength(1);
-      expect(result[0].href).toBe('/blog/published-note');
+      expect(result[0].href).toBe('/blog/2026-06-21-published-note');
     });
 
     it('slug와 encodedSlug로 포스트를 찾는다', () => {

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -5,6 +5,21 @@ import { getStaticPostList } from '@/libs/staticPostData';
 
 export const dynamic = 'force-static';
 
+function escapeMarkdownLinkText(value: string): string {
+  return value.replace(/([\\[\]])/g, '\\$1');
+}
+
+function formatPostContext(post: ReturnType<typeof getStaticPostList>[number]): string {
+  const parts = [
+    post.publishedAt ? `published ${post.publishedAt}` : '',
+    post.updatedAt ? `updated ${post.updatedAt}` : '',
+    post.category?.text ? `category ${post.category.text}` : '',
+    post.tags.length > 0 ? `tags ${post.tags.join(', ')}` : '',
+  ].filter(Boolean);
+
+  return parts.length > 0 ? ` (${parts.join('; ')})` : '';
+}
+
 /**
  * llms.txt 생성 (llmstxt.org 표준)
  *
@@ -18,8 +33,9 @@ export async function GET() {
   const postLines = posts
     .map(post => {
       const url = `${baseUrl}/blog/${post.slug}/`;
+      const title = escapeMarkdownLinkText(post.title);
       const description = post.description?.replace(/\s+/g, ' ').trim() || post.title;
-      return `- [${post.title}](${url}): ${description}`;
+      return `- [${title}](${url})${formatPostContext(post)}: ${description}`;
     })
     .join('\n');
 
@@ -33,6 +49,7 @@ export async function GET() {
 - [Blog](${baseUrl}/blog/): 모든 블로그 포스트 목록
 - [Sitemap](${baseUrl}/sitemap.xml): 전체 URL 목록
 - [Feed](${baseUrl}/feed.xml): RSS 2.0 피드
+- [Robots](${baseUrl}/robots.txt): crawler access policy
 
 ## Posts
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,6 +6,15 @@ import { getStaticPostList } from '@/libs/staticPostData';
 // 정적 내보내기를 위한 설정
 export const dynamic = 'force-static';
 
+function toSitemapDate(value?: string): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
 /**
  * Sitemap.xml 생성
  *
@@ -15,36 +24,37 @@ export const dynamic = 'force-static';
  */
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = SITE_CONFIG.url;
+  const posts = getStaticPostList();
+  const latestPostDate = posts
+    .map(post => toSitemapDate(post.updatedAt || post.publishedAt || post.lastEditedAt))
+    .filter((date): date is Date => Boolean(date))
+    .sort((a, b) => b.getTime() - a.getTime())[0];
 
   // 정적 페이지들
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      lastModified: latestPostDate,
       changeFrequency: 'daily',
       priority: 1,
     },
     {
       url: `${baseUrl}/blog`,
-      lastModified: new Date(),
+      lastModified: latestPostDate,
       changeFrequency: 'daily',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/about`,
-      lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.6,
     },
   ];
 
   // 블로그 포스트들 (정적 데이터에서 가져오기)
-  const posts = getStaticPostList();
   const blogPosts: MetadataRoute.Sitemap = posts.map(post => ({
     url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: new Date(
-      post.updatedAt || post.publishedAt || post.lastEditedAt || post.createdAt,
-    ),
+    lastModified: toSitemapDate(post.updatedAt || post.publishedAt || post.lastEditedAt),
     changeFrequency: 'weekly' as const,
     priority: 0.7,
   }));

--- a/src/components/ui/blog/PostBody/PostBody.stories.tsx
+++ b/src/components/ui/blog/PostBody/PostBody.stories.tsx
@@ -60,7 +60,7 @@ export const Default: Story = {
     markdown: sampleMarkdown,
     linkMaps: {
       published: {
-        'second-note': '/blog/second-note',
+        'second-note': '/blog/2026-06-20-second-note',
       },
       sources: {},
       sourceLabels: {},

--- a/src/libs/content/linkResolver.ts
+++ b/src/libs/content/linkResolver.ts
@@ -1,7 +1,14 @@
 import path from 'node:path';
 
+import { SITE_CONFIG } from '@/constants';
+
 import { slugifyHeading } from './slug';
 import type { ContentIndex, ContentLinkMaps, KbNote, LinkResolution } from './types';
+
+const SITE_HOSTNAME = SITE_CONFIG.url
+  .replace(/^https?:\/\//i, '')
+  .replace(/\/.*$/, '')
+  .replace(/^www\./i, '');
 
 interface ParsedTarget {
   page: string;
@@ -33,6 +40,58 @@ function isMarkdownHref(href: string): boolean {
   return /\.mdx?$/i.test(pathname);
 }
 
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseInternalBlogHref(href: string): { slug: string; hash: string } | null {
+  let pathWithHash = href;
+
+  if (!href.startsWith('/')) {
+    const hostPattern = SITE_HOSTNAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = href.match(new RegExp(`^https?://(?:www\\.)?${hostPattern}(/.*)?$`, 'i'));
+    if (!match) {
+      return null;
+    }
+
+    pathWithHash = match[1] || '/';
+  }
+
+  const hashIndex = pathWithHash.indexOf('#');
+  const pathname = hashIndex === -1 ? pathWithHash : pathWithHash.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : pathWithHash.slice(hashIndex);
+  const match = pathname.match(/^\/blog\/([^/?]+)\/?$/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    slug: match[1],
+    hash,
+  };
+}
+
+function resolveDirectBlogHref(href: string, maps: ContentLinkMaps): string | null {
+  const parsed = parseInternalBlogHref(href);
+  if (!parsed) {
+    return null;
+  }
+
+  const rawSlug = parsed.slug;
+  const resolvedHref = maps.published[rawSlug] ?? maps.published[safeDecodeURIComponent(rawSlug)];
+
+  if (!resolvedHref) {
+    return null;
+  }
+
+  return `${resolvedHref}${parsed.hash}`;
+}
+
 export function resolveWikiLink(
   target: string,
   label: string | undefined,
@@ -42,10 +101,17 @@ export function resolveWikiLink(
 }
 
 export function createContentLinkMaps(index: ContentIndex): ContentLinkMaps {
+  const publishedEntries = Array.from(index.publishedByBasename.entries()).map(([key, note]) => [
+    key,
+    note.href,
+  ]);
+
+  for (const note of index.publishedNotes) {
+    publishedEntries.push([note.slug, note.href]);
+  }
+
   return {
-    published: Object.fromEntries(
-      Array.from(index.publishedByBasename.entries()).map(([key, note]) => [key, note.href]),
-    ),
+    published: Object.fromEntries(publishedEntries),
     sources: Object.fromEntries(index.sourceUrlByBasename.entries()),
     sourceLabels: Object.fromEntries(index.sourceLabelByBasename.entries()),
   };
@@ -94,6 +160,16 @@ export function resolveMarkdownLink(
   fromNote: KbNote,
   index: ContentIndex,
 ): LinkResolution {
+  const normalizedBlogHref = resolveDirectBlogHref(href, createContentLinkMaps(index));
+  if (normalizedBlogHref) {
+    return {
+      kind: 'internal',
+      label,
+      target: href,
+      href: normalizedBlogHref,
+    };
+  }
+
   if (isExternalHref(href) || href.startsWith('#') || !isMarkdownHref(href)) {
     return {
       kind: isExternalHref(href) ? 'external' : 'internal',

--- a/src/libs/content/postMeta.ts
+++ b/src/libs/content/postMeta.ts
@@ -12,7 +12,7 @@ import {
   resolveCategoryRgb,
 } from './category';
 import { normalizeFrontmatter } from './frontmatter';
-import { createPostSlug } from './slug';
+import { createDatedPostSlug } from './slug';
 import type { ContentFrontmatter, KbNote } from './types';
 
 function formatContentDate(value: string | undefined): string {
@@ -103,7 +103,11 @@ export function readExportedContentNotes(contentRoot: string): KbNote[] {
     const basename = path.basename(filePath);
     const slugFromDirectory = path.basename(path.dirname(filePath));
     const frontmatter = normalizeFrontmatter(parsed.data as Record<string, unknown>);
-    const slug = createPostSlug(slugFromDirectory, frontmatter.slug);
+    const slug = createDatedPostSlug(
+      slugFromDirectory,
+      frontmatter.slug,
+      frontmatter.added || frontmatter.published_at,
+    );
 
     return {
       absolutePath: path.resolve(filePath),
@@ -148,7 +152,11 @@ export function createPostMetaList(notes: KbNote[]): PostMeta[] {
   });
 
   return sorted.map((note, index) => {
-    const slug = createPostSlug(note.stem, note.frontmatter.slug);
+    const slug = createDatedPostSlug(
+      note.stem,
+      note.frontmatter.slug,
+      note.frontmatter.added || note.frontmatter.published_at,
+    );
     const date = getPostDate(note.frontmatter);
     const updated = note.frontmatter.updated || date;
     const categoryText = getPostCategoryText(note);

--- a/src/libs/content/scanner.ts
+++ b/src/libs/content/scanner.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { parseKbMarkdownFile } from './frontmatter';
-import { createPostSlug } from './slug';
+import { createDatedPostSlug } from './slug';
 import type { ContentDiagnostic, ContentIndex, KbNote, PublishedContentNote } from './types';
 
 const MARKDOWN_EXTENSION = /\.mdx?$/i;
@@ -43,7 +43,11 @@ function addBasenameIndex(index: Map<string, KbNote[]>, note: KbNote) {
 }
 
 function createPublishedNote(note: KbNote): PublishedContentNote {
-  const slug = createPostSlug(note.stem, note.frontmatter.slug);
+  const slug = createDatedPostSlug(
+    note.stem,
+    note.frontmatter.slug,
+    note.frontmatter.added || note.frontmatter.published_at,
+  );
 
   return {
     ...note,

--- a/src/libs/content/slug.ts
+++ b/src/libs/content/slug.ts
@@ -27,3 +27,37 @@ export function slugifyHeading(rawValue: string): string {
 export function createPostSlug(fileStem: string, frontmatterSlug?: string): string {
   return slugifyPost(frontmatterSlug || fileStem);
 }
+
+function normalizePostSlugDate(value?: string): string | undefined {
+  const trimmed = value?.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) {
+    return trimmed.slice(0, 10);
+  }
+
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+export function createDatedPostSlug(
+  fileStem: string,
+  frontmatterSlug?: string,
+  date?: string,
+): string {
+  const slug = createPostSlug(fileStem, frontmatterSlug);
+  const datePrefix = normalizePostSlugDate(date);
+
+  if (!datePrefix) {
+    return slug;
+  }
+
+  return `${datePrefix}-${slug.replace(/^\d{4}-\d{2}-\d{2}-/, '')}`;
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -566,9 +566,7 @@
   border: 0;
   border-radius: 0.375rem;
   background: var(--bg-color-1);
-  box-shadow:
-    0 0 0 0.0625rem var(--fg-color-1),
-    0 0.125rem 0.5rem var(--fg-color-0);
+  box-shadow: 0 0.125rem 0.5rem var(--fg-color-0);
   color: var(--fg-color);
   cursor: pointer;
   text-decoration: none;

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
@@ -6,6 +6,7 @@ description: 'A published fixture note.'
 tags: [blog, fixture]
 publish: true
 slug: published-note
+added: 2026-06-21
 published_at: 2026-06-21
 updated: 2026-06-21
 cover: ./assets/cover.svg
@@ -18,6 +19,9 @@ This published note links to [[second-note|another note]], [[youtube-source|the 
 
 It also links with markdown syntax to [second](./second-note.md), [source](../sources/youtube-source.md),
 and [private](../sources/private-source.md).
+
+Direct blog URLs should also be normalized: [internal old URL](/blog/second-note) and
+[absolute old URL](https://r3gardless.dev/blog/second-note#details-section).
 
 Bold source wikilinks should survive export: **[[youtube-source|PostgreSQL 자체 Git 저장소]]**.
 

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/second-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/second-note.md
@@ -5,6 +5,7 @@ title: 'Second Note'
 description: 'A second fixture post for validating the content pipeline.'
 tags: [blog]
 publish: true
+added: 2026-06-20
 published_at: 2026-06-20
 updated: 2026-06-21
 ---


### PR DESCRIPTION
## Summary
- Build published blog routes as `/blog/<added>-<slug>` and propagate that slug through exported content, post metadata, sitemap, feed, and link maps.
- Rewrite direct internal blog links that still use old slugs to the dated canonical URL, and fail `check-content` if old internal blog links remain.
- Keep compact reference cards borderless at rest and show the boundary only on hover.
- Improve GEO surfaces by adding post context to `llms.txt`, escaping Markdown link labels there, and making sitemap `lastmod` stable from content dates.

## Verification
- `bun run verify`
- push hook: private KB sync + production build