### PR TITLE
feat(blog): PostBody 렌더링·디자인 개편 (코드블록·캡션·mermaid·표·reading time, Notion 탈피)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,15 +59,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # 방금 checkout한 최신 KNOWLEDGE_BASE로 content/posts·postMeta를 명시적으로
-      # 재생성합니다. next build의 prebuild 훅에만 의존하면(중첩 `bun run build`에서
-      # 훅이 실행되지 않을 수 있어) 옛 산출물이 그대로 배포될 위험이 있으므로, 배포에서는
-      # 명시 단계로 프레시 콘텐츠 생성을 보장합니다.
-      - name: Build content from fresh KNOWLEDGE_BASE
-        run: |
-          bun run build:content
-          bun run build:meta
-
+      # verify의 `bun run build`(next build)가 prebuild 훅(build:content && build:meta)을
+      # 태워, 방금 checkout한 최신 KNOWLEDGE_BASE로 content/posts·postMeta를 재생성합니다.
+      # 별도 명시 단계는 중복이라 두지 않습니다.
       - name: Verify
         run: bun run verify
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # 방금 checkout한 최신 KNOWLEDGE_BASE로 content/posts·postMeta를 명시적으로
+      # 재생성합니다. next build의 prebuild 훅에만 의존하면(중첩 `bun run build`에서
+      # 훅이 실행되지 않을 수 있어) 옛 산출물이 그대로 배포될 위험이 있으므로, 배포에서는
+      # 명시 단계로 프레시 콘텐츠 생성을 보장합니다.
+      - name: Build content from fresh KNOWLEDGE_BASE
+        run: |
+          bun run build:content
+          bun run build:meta
+
       - name: Verify
         run: bun run verify
 

--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -716,8 +716,16 @@ function checkMarkdownCss(errors: string[]) {
   const css = fs.readFileSync(cssPath, 'utf8');
   const relativeFile = path.relative(PROJECT_ROOT, cssPath);
 
-  if (!css.includes('font-family: var(--font-pretendard), var(--notion-font), sans-serif;')) {
-    errors.push(`${relativeFile}: .post-body must use Pretendard as the body font.`);
+  if (!css.includes('--pb-sans:') || !css.includes('var(--font-pretendard)')) {
+    errors.push(
+      `${relativeFile}: .post-body must use Pretendard (via --pb-sans) as the body font.`,
+    );
+  }
+
+  if (/var\(--(?:fg-color|bg-color|notion-)/.test(css) || /--notion-font\s*:/.test(css)) {
+    errors.push(
+      `${relativeFile}: Markdown body must not reintroduce Notion-era tokens (--fg-color/--bg-color/--notion-*).`,
+    );
   }
 
   if (/\.post-body\s*\{[\s\S]*?font-family:\s*var\(--font-maruBuri\)/.test(css)) {
@@ -885,7 +893,7 @@ function checkMarkdownCss(errors: string[]) {
     ['width', '100%'],
     ['padding', '1.1rem 0.75rem'],
     ['gap', '0.75rem'],
-    ['border', '0.0625rem solid var(--fg-color-1)'],
+    ['border', '0.0625rem solid var(--pb-border-strong)'],
     ['border-radius', '0.375rem'],
     ['background', 'transparent'],
     ['box-shadow', 'none'],
@@ -895,7 +903,7 @@ function checkMarkdownCss(errors: string[]) {
 
   requireCssDeclarations(css, relativeFile, errors, '.post-body .reference-card:hover', [
     ['border-color', 'transparent'],
-    ['box-shadow', '0 0 0 0.0625rem var(--fg-color-2), 0 0.1875rem 0.75rem var(--fg-color-1)'],
+    ['box-shadow', '0 0 0 0.0625rem var(--pb-faint), 0 0.1875rem 0.75rem var(--pb-border-strong)'],
   ]);
 
   requireCssDeclarations(css, relativeFile, errors, '.post-body .reference-card-title', [
@@ -945,7 +953,7 @@ function checkMarkdownCss(errors: string[]) {
     errors.push(`${relativeFile}: Markdown callouts must keep a visible background.`);
   }
 
-  if (!css.includes('background: var(--markdown-alert-bg);')) {
+  if (!css.includes('background: var(--pb-alert-bg);')) {
     errors.push(`${relativeFile}: Markdown callouts must use the alert background variable.`);
   }
 

--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -748,90 +748,52 @@ function checkMarkdownCss(errors: string[]) {
     );
   }
 
+  // 본문 문단/리스트는 KB의 강제 줄바꿈을 살리기 위해 pre-wrap/word-break를 유지해야 합니다.
   requireCssDeclarations(css, relativeFile, errors, '.post-body p', [
-    ['margin', '0.0625rem 0'],
-    ['padding', '0.1875rem 0.125rem'],
-    ['font-size', '1rem'],
-    ['line-height', '1.6'],
     ['white-space', 'pre-wrap'],
     ['word-break', 'break-word'],
   ]);
 
-  requireCssDeclarations(css, relativeFile, errors, '.post-body ul', [
-    ['padding-inline-start', '1.7rem'],
-    ['list-style-type', 'disc'],
-  ]);
+  requireCssDeclarations(css, relativeFile, errors, '.post-body ul', [['list-style-type', 'disc']]);
 
   requireCssDeclarations(css, relativeFile, errors, '.post-body ol', [
-    ['padding-inline-start', '1.6rem'],
     ['list-style-type', 'decimal'],
   ]);
 
-  requireCssDeclarations(css, relativeFile, errors, '.post-body li', [
-    ['padding', '0.375rem 0'],
-    ['white-space', 'pre-wrap'],
-  ]);
+  requireCssDeclarations(css, relativeFile, errors, '.post-body li', [['white-space', 'pre-wrap']]);
 
+  // 모던 PostBody 토큰(--pb-*) 사용을 고정합니다. 인라인 코드는 빨간 계열(--pb-inline-code)을 유지합니다.
   requireCssDeclarations(css, relativeFile, errors, '.post-body :not(pre) > code', [
-    ['padding', '0.2rem 0.4rem'],
-    ['border-radius', '0.1875rem'],
-    ['background', 'var(--bg-color-2)'],
-    ['color', '#eb5757'],
-    ['font-size', '85%'],
+    ['background', 'var(--pb-surface)'],
+    ['color', 'var(--pb-inline-code)'],
   ]);
 
   requireCssDeclarations(css, relativeFile, errors, '.post-body pre', [
-    ['margin', '0.25rem 0'],
-    ['padding', '1rem'],
-    ['border-radius', '0.1875rem'],
-    ['background', 'var(--bg-color-1)'],
-    ['color', 'var(--fg-color)'],
-    ['font-size', '0.875rem'],
+    ['background', 'var(--pb-surface)'],
+    ['color', 'var(--pb-text)'],
     ['tab-size', '2'],
   ]);
 
-  requireCssDeclarations(css, relativeFile, errors, '.post-body table', [
-    ['display', 'block'],
-    ['width', '100%'],
-    ['margin', '0.25rem 0'],
-    ['font-size', '1rem'],
-  ]);
+  requireCssDeclarations(css, relativeFile, errors, '.post-body table', [['display', 'block']]);
 
+  // 표 셀은 긴 내용이 셀 밖으로 넘치지 않도록 wrap 관련 선언을 유지해야 합니다.
   if (
-    !/\.post-body th,\s*\.post-body td\s*\{[\s\S]*?padding:\s*0\.5rem;[\s\S]*?border:\s*0\.0625rem solid var\(--fg-color-5\);[\s\S]*?white-space:\s*normal;[\s\S]*?word-break:\s*break-word;[\s\S]*?overflow-wrap:\s*break-word;/.test(
+    !/\.post-body th,\s*\.post-body td\s*\{[\s\S]*?white-space:\s*normal;[\s\S]*?word-break:\s*break-word;[\s\S]*?overflow-wrap:\s*break-word;/.test(
       css,
     )
   ) {
-    errors.push(`${relativeFile}: table cells must keep the old Notion-like cell spacing.`);
+    errors.push(`${relativeFile}: table cells must keep wrapping declarations for long content.`);
   }
 
   if (!/\.post-body blockquote > p\s*\{[\s\S]*?margin:\s*0;[\s\S]*?padding:\s*0;/.test(css)) {
     errors.push(
-      `${relativeFile}: blockquote paragraph padding must be reset so quote vertical padding matches the old Notion style.`,
+      `${relativeFile}: blockquote paragraph margin/padding must be reset so quote spacing stays clean.`,
     );
-  }
-
-  if (
-    !/\.post-body blockquote\s*\{[\s\S]*?margin:\s*0\.25rem 0;[\s\S]*?padding:\s*0\.15rem 0\.9rem;/.test(
-      css,
-    )
-  ) {
-    errors.push(`${relativeFile}: blockquote vertical padding must stay compact.`);
   }
 
   if (/\.post-body blockquote\s*\{[^}]*white-space:\s*pre-wrap;/.test(css)) {
     errors.push(
       `${relativeFile}: blockquote itself must not use pre-wrap because renderer whitespace becomes visible blank lines.`,
-    );
-  }
-
-  if (
-    !/\.post-body pre\s*\{[\s\S]*?background:\s*var\(--bg-color-1\);[\s\S]*?color:\s*var\(--fg-color\);/.test(
-      css,
-    )
-  ) {
-    errors.push(
-      `${relativeFile}: code blocks must keep the old Notion-like bg-color-1 background and fg-color foreground.`,
     );
   }
 

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -164,7 +164,7 @@ function checkRenderedPost(post: PostMeta, errors: string[]) {
     [features.table, '<table', 'GFM table'],
     [features.math, 'katex', 'KaTeX'],
     [features.mermaid, 'mermaid', 'Mermaid'],
-    [features.code, 'data-rehype-pretty-code-figure', 'code highlight'],
+    [features.code, 'code-block-language', 'code block chrome'],
     [features.details, '<details', 'Markdown details'],
     [features.references, 'reference-card', 'compact reference card'],
     [features.image, 'markdown-image-trigger', 'markdown image lightbox trigger'],

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -344,18 +344,16 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
     errors.push('Built Markdown CSS must reset blockquote paragraph margin and padding.');
   }
 
-  if (!/\.post-body blockquote\{[^}]*margin:\.25rem 0[^}]*padding:\.15rem \.9rem/.test(css)) {
-    errors.push('Built Markdown CSS must keep compact blockquote vertical padding.');
-  }
-
   if (/\.post-body blockquote\{[^}]*white-space:pre-wrap/.test(css)) {
     errors.push('Built Markdown CSS must not preserve renderer whitespace inside blockquotes.');
   }
 
   if (
-    !/\.post-body pre\{[^}]*background:var\(--bg-color-1\)[^}]*color:var\(--fg-color\)/.test(css)
+    !/\.post-body pre\{[^}]*background:var\(--pb-surface\)[^}]*color:var\(--pb-text\)/.test(css)
   ) {
-    errors.push('Built Markdown CSS must keep Notion-like code block background and foreground.');
+    errors.push(
+      'Built Markdown CSS must render code blocks on the modern --pb-surface background.',
+    );
   }
 
   if (!css.includes('color:var(--shiki-light)')) {
@@ -462,9 +460,9 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
   }
 
   if (
-    !/\.post-body \.markdown-details\{[^}]*background:var\(--bg-color-1\)/.test(css) ||
+    !/\.post-body \.markdown-details\{[^}]*background:var\(--pb-surface\)/.test(css) ||
     !/\.post-body \.markdown-details-summary\{[^}]*cursor:pointer/.test(css) ||
-    !/\.post-body \.markdown-details-content\{[^}]*border-top:\.0625rem solid var\(--fg-color-0\)/.test(
+    !/\.post-body \.markdown-details-content\{[^}]*border-top:\.0625rem solid var\(--pb-border\)/.test(
       css,
     )
   ) {

--- a/scripts/smoke-build-output.ts
+++ b/scripts/smoke-build-output.ts
@@ -336,7 +336,7 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
     errors.push('Built Markdown CSS must not render callouts with a transparent background.');
   }
 
-  if (!/\.post-body \.markdown-alert\{[^}]*background:var\(--markdown-alert-bg\)/.test(css)) {
+  if (!/\.post-body \.markdown-alert\{[^}]*background:var\(--pb-alert-bg\)/.test(css)) {
     errors.push('Built Markdown CSS is missing the callout background variable.');
   }
 
@@ -433,7 +433,7 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
   if (
     !referenceCardRule.includes('display:flex') ||
     !referenceCardRule.includes('padding:1.1rem .75rem') ||
-    !referenceCardRule.includes('border:.0625rem solid var(--fg-color-1)') ||
+    !referenceCardRule.includes('border:.0625rem solid var(--pb-border-strong)') ||
     !referenceCardRule.includes('background:0 0') ||
     !referenceCardRule.includes('box-shadow:none') ||
     !referenceCardRule.includes('cursor:pointer')
@@ -443,7 +443,7 @@ function checkBuiltMarkdownStyles(outRoot: string, errors: string[]) {
 
   if (
     !referenceCardHoverRule.includes(
-      'box-shadow:0 0 0 .0625rem var(--fg-color-2), 0 .1875rem .75rem var(--fg-color-1)',
+      'box-shadow:0 0 0 .0625rem var(--pb-faint), 0 .1875rem .75rem var(--pb-border-strong)',
     )
   ) {
     errors.push('Built Markdown CSS must show compact reference card boundary on hover.');

--- a/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
+++ b/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
@@ -21,12 +21,9 @@ describe('Mermaid initialize configuration', () => {
     expect(source).toMatch(/flowchart:\s*\{\s*htmlLabels:\s*true\s*\}/);
   });
 
-  it('applies a PostBody theme fallback that diagram-defined colors override', () => {
-    // 색 지정이 없는 다이어그램은 PostBody 톤을 따르고, 지정된 색은 이 폴백을 덮어씁니다.
-    expect(source).toContain("theme: 'base'");
-    expect(source).toContain('themeVariables');
-    expect(source).toContain('postBodyThemeVariables');
-    // 라이트/다크 폴백 색을 적용하기 위해 사이트 테마를 관찰해야 합니다.
-    expect(source).toContain("attributeFilter: ['data-theme']");
+  it('does not override mermaid default colors or force a site theme', () => {
+    // mermaid 기본값만 사용합니다. 사이트 테마/themeVariables를 주입하지 않습니다.
+    expect(source).not.toContain("theme: 'base'");
+    expect(source).not.toContain('themeVariables');
   });
 });

--- a/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
+++ b/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
@@ -5,18 +5,20 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Mermaid는 클라이언트에서 실제 브라우저 레이아웃(getBBox 등)을 필요로 해 jsdom에서
- * 온전히 렌더할 수 없습니다. 대신 렌더 품질을 좌우하는 초기화 설정이 회귀하지 않도록
- * 소스 수준에서 고정합니다.
+ * 온전히 렌더할 수 없습니다. 대신 렌더 품질을 좌우하는 초기화/격리 설정이 회귀하지
+ * 않도록 소스 수준에서 고정합니다.
  */
 const source = fs.readFileSync(
   path.join(process.cwd(), 'src/components/ui/blog/Mermaid/Mermaid.tsx'),
   'utf8',
 );
 
-describe('Mermaid initialize configuration', () => {
-  it('keeps htmlLabels on via loose securityLevel so <br/> and custom fonts render', () => {
-    // strict/antiscript는 htmlLabels를 꺼서 `<br/>` 줄바꿈이 사라지고 폰트 폭이 잘립니다.
-    expect(source).toContain("securityLevel: 'loose'");
+describe('Mermaid rendering configuration', () => {
+  it('keeps htmlLabels on (antiscript) so <br/> and custom fonts render, without loose scripts', () => {
+    // strict는 htmlLabels를 꺼서 `<br/>` 줄바꿈이 사라지고 폰트 폭이 잘립니다.
+    // antiscript는 htmlLabels를 허용하되 스크립트는 제거해 loose보다 안전합니다.
+    expect(source).toContain("securityLevel: 'antiscript'");
+    expect(source).not.toContain("securityLevel: 'loose'");
     expect(source).toMatch(/htmlLabels:\s*true/);
     expect(source).toMatch(/flowchart:\s*\{\s*htmlLabels:\s*true\s*\}/);
   });
@@ -25,5 +27,18 @@ describe('Mermaid initialize configuration', () => {
     // mermaid 기본값만 사용합니다. 사이트 테마/themeVariables를 주입하지 않습니다.
     expect(source).not.toContain("theme: 'base'");
     expect(source).not.toContain('themeVariables');
+  });
+
+  it('waits for fonts to load before rendering to avoid clipped labels', () => {
+    // 커스텀 폰트 로드 전 렌더하면 라벨 폭 계산이 어긋나 끝 글자가 잘립니다.
+    expect(source).toContain('document.fonts');
+    expect(source).toMatch(/await\s+document\.fonts\.ready/);
+  });
+
+  it('isolates the diagram in a Shadow DOM so page CSS cannot bleed into labels', () => {
+    // Shadow DOM이 없으면 globals의 p { color } 등이 라벨로 새어들어 색이 씻기거나
+    // 폭이 어긋나 글자가 잘립니다.
+    expect(source).toContain('attachShadow');
+    expect(source).toMatch(/mermaid\.render\(/);
   });
 });

--- a/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
+++ b/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Mermaid는 클라이언트에서 실제 브라우저 레이아웃(getBBox 등)을 필요로 해 jsdom에서
+ * 온전히 렌더할 수 없습니다. 대신 렌더 품질을 좌우하는 초기화 설정이 회귀하지 않도록
+ * 소스 수준에서 고정합니다.
+ */
+const source = fs.readFileSync(
+  path.join(process.cwd(), 'src/components/ui/blog/Mermaid/Mermaid.tsx'),
+  'utf8',
+);
+
+describe('Mermaid initialize configuration', () => {
+  it('keeps htmlLabels on via loose securityLevel so <br/> and custom fonts render', () => {
+    // strict/antiscript는 htmlLabels를 꺼서 `<br/>` 줄바꿈이 사라지고 폰트 폭이 잘립니다.
+    expect(source).toContain("securityLevel: 'loose'");
+    expect(source).toMatch(/htmlLabels:\s*true/);
+    expect(source).toMatch(/flowchart:\s*\{\s*htmlLabels:\s*true\s*\}/);
+  });
+
+  it('applies a PostBody theme fallback that diagram-defined colors override', () => {
+    // 색 지정이 없는 다이어그램은 PostBody 톤을 따르고, 지정된 색은 이 폴백을 덮어씁니다.
+    expect(source).toContain("theme: 'base'");
+    expect(source).toContain('themeVariables');
+    expect(source).toContain('postBodyThemeVariables');
+    // 라이트/다크 폴백 색을 적용하기 위해 사이트 테마를 관찰해야 합니다.
+    expect(source).toContain("attributeFilter: ['data-theme']");
+  });
+});

--- a/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
+++ b/src/__tests__/components/ui/blog/Mermaid/Mermaid.config.test.ts
@@ -41,4 +41,17 @@ describe('Mermaid rendering configuration', () => {
     expect(source).toContain('attachShadow');
     expect(source).toMatch(/mermaid\.render\(/);
   });
+
+  it('injects the SVG via DOMParser nodes, not string innerHTML', () => {
+    // 문자열 innerHTML 주입 대신 inert 파싱 후 노드 삽입으로 XSS/DOM 클로버링을 줄입니다.
+    expect(source).toContain('DOMParser');
+    expect(source).toMatch(/importNode/);
+    expect(source).not.toMatch(/shadow\.innerHTML\s*=/);
+  });
+
+  it('localizes the diagram accessibility label by lang', () => {
+    // en/ja 글에서 한국어 aria-label이 노출되지 않도록 lang으로 로컬라이즈합니다.
+    expect(source).toMatch(/aria-label=\{DIAGRAM_LABEL/);
+    expect(source).toContain("en: 'Diagram'");
+  });
 });

--- a/src/__tests__/libs/content/imageAlt.test.ts
+++ b/src/__tests__/libs/content/imageAlt.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractImageAltAtStart, unescapeMarkersInImageAlts } from '@/libs/content/imageAlt';
+
+describe('extractImageAltAtStart', () => {
+  it('extracts a plain alt', () => {
+    expect(extractImageAltAtStart('![hello](/x.png)')).toBe('hello');
+  });
+
+  it('keeps nested balanced brackets in the alt', () => {
+    expect(extractImageAltAtStart('![a [b] c](/x.png)')).toBe('a [b] c');
+    expect(extractImageAltAtStart('![a [b [c] d] e](/x.png)')).toBe('a [b [c] d] e');
+  });
+
+  it('keeps escaped brackets and emphasis markers', () => {
+    expect(extractImageAltAtStart('![a \\] b](/x.png)')).toBe('a \\] b');
+    expect(extractImageAltAtStart('![*i* **b** ~~d~~](/x.png)')).toBe('*i* **b** ~~d~~');
+  });
+
+  it('returns null when not a valid image start', () => {
+    expect(extractImageAltAtStart('[link](/x)')).toBeNull();
+    expect(extractImageAltAtStart('![no closing paren]')).toBeNull();
+    expect(extractImageAltAtStart('![alt] not an image')).toBeNull();
+  });
+});
+
+describe('unescapeMarkersInImageAlts', () => {
+  it('unescapes emphasis/strike/code/math markers inside image alts only', () => {
+    const input = '![\\*i\\* \\~\\~d\\~\\~ \\`c\\` \\$x\\$](/x.png) and \\*keep\\* outside';
+    expect(unescapeMarkersInImageAlts(input)).toBe(
+      '![*i* ~~d~~ `c` $x$](/x.png) and \\*keep\\* outside',
+    );
+  });
+
+  it('handles nested brackets without corrupting the alt', () => {
+    const input = '![a \\[b\\] \\*i\\* [n]](/x.png)';
+    expect(unescapeMarkersInImageAlts(input)).toBe('![a \\[b\\] *i* [n]](/x.png)');
+  });
+
+  it('leaves text without images unchanged', () => {
+    expect(unescapeMarkersInImageAlts('no images here \\* \\_')).toBe('no images here \\* \\_');
+  });
+});

--- a/src/__tests__/libs/content/readingTime.test.ts
+++ b/src/__tests__/libs/content/readingTime.test.ts
@@ -28,6 +28,9 @@ describe('reading_time frontmatter', () => {
     expect(normalizeFrontmatter({ reading_time: '4.6 min' }).reading_time).toBe(5);
     expect(normalizeFrontmatter({ reading_time: 0 }).reading_time).toBeUndefined();
     expect(normalizeFrontmatter({ reading_time: -3 }).reading_time).toBeUndefined();
+    // 반올림해서 0이 되는 값(예: 0.4)은 유효한 읽기 시간이 아니므로 undefined.
+    expect(normalizeFrontmatter({ reading_time: 0.4 }).reading_time).toBeUndefined();
+    expect(normalizeFrontmatter({ reading_time: '0.4 min' }).reading_time).toBeUndefined();
     expect(normalizeFrontmatter({ reading_time: 'abc' }).reading_time).toBeUndefined();
     expect(normalizeFrontmatter({}).reading_time).toBeUndefined();
   });

--- a/src/__tests__/libs/content/readingTime.test.ts
+++ b/src/__tests__/libs/content/readingTime.test.ts
@@ -22,7 +22,10 @@ describe('reading_time frontmatter', () => {
     expect(normalizeFrontmatter({ reading_time: 5 }).reading_time).toBe(5);
     expect(normalizeFrontmatter({ reading_time: '7' }).reading_time).toBe(7);
     expect(normalizeFrontmatter({ reading_time: '8 min' }).reading_time).toBe(8);
+    // 숫자/문자열 모두 소수는 동일하게 반올림합니다(parseInt 절삭 불일치 방지).
     expect(normalizeFrontmatter({ reading_time: 4.6 }).reading_time).toBe(5);
+    expect(normalizeFrontmatter({ reading_time: '4.6' }).reading_time).toBe(5);
+    expect(normalizeFrontmatter({ reading_time: '4.6 min' }).reading_time).toBe(5);
     expect(normalizeFrontmatter({ reading_time: 0 }).reading_time).toBeUndefined();
     expect(normalizeFrontmatter({ reading_time: -3 }).reading_time).toBeUndefined();
     expect(normalizeFrontmatter({ reading_time: 'abc' }).reading_time).toBeUndefined();

--- a/src/__tests__/libs/content/readingTime.test.ts
+++ b/src/__tests__/libs/content/readingTime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeFrontmatter } from '@/libs/content/frontmatter';
+import { createPostMetaList } from '@/libs/content/postMeta';
+import type { KbNote } from '@/libs/content/types';
+
+function makeNote(frontmatter: Record<string, unknown>): KbNote {
+  return {
+    absolutePath: '/kb/note.md',
+    relativePath: 'note.md',
+    dirRelativePath: '',
+    basename: 'note.md',
+    stem: 'note',
+    lang: 'kr',
+    content: 'Body text.',
+    frontmatter: normalizeFrontmatter({ title: 'Note', added: '2026-01-02', ...frontmatter }),
+  };
+}
+
+describe('reading_time frontmatter', () => {
+  it('normalizes reading_time to a positive integer number of minutes', () => {
+    expect(normalizeFrontmatter({ reading_time: 5 }).reading_time).toBe(5);
+    expect(normalizeFrontmatter({ reading_time: '7' }).reading_time).toBe(7);
+    expect(normalizeFrontmatter({ reading_time: '8 min' }).reading_time).toBe(8);
+    expect(normalizeFrontmatter({ reading_time: 4.6 }).reading_time).toBe(5);
+    expect(normalizeFrontmatter({ reading_time: 0 }).reading_time).toBeUndefined();
+    expect(normalizeFrontmatter({ reading_time: -3 }).reading_time).toBeUndefined();
+    expect(normalizeFrontmatter({ reading_time: 'abc' }).reading_time).toBeUndefined();
+    expect(normalizeFrontmatter({}).reading_time).toBeUndefined();
+  });
+
+  it('maps reading_time into PostMeta.readingTime', () => {
+    const [meta] = createPostMetaList([makeNote({ reading_time: 6 })]);
+    expect(meta.readingTime).toBe(6);
+  });
+
+  it('leaves readingTime undefined when reading_time is absent', () => {
+    const [meta] = createPostMetaList([makeNote({})]);
+    expect(meta.readingTime).toBeUndefined();
+  });
+});

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -294,10 +294,21 @@ on:
     fireEvent.click(toggle as Element);
     expect(container.querySelector('.code-block-content')).not.toHaveAttribute('data-collapsed');
 
+    const originalClipboard = navigator.clipboard;
     const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText } });
-    fireEvent.click(container.querySelector('.code-block-copy') as Element);
-    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('const line0 = 0;'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    try {
+      fireEvent.click(container.querySelector('.code-block-copy') as Element);
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('const line0 = 0;'));
+    } finally {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: originalClipboard,
+        configurable: true,
+      });
+    }
   });
 
   it('renders inline markdown emphasis inside image captions', async () => {
@@ -313,6 +324,52 @@ on:
     expect(caption?.querySelector('strong')).toHaveTextContent('bold');
     // 원본 마크다운 별표가 캡션에 그대로 노출되면 안 됩니다.
     expect(caption?.textContent).not.toContain('*');
+  });
+
+  it('renders composite inline formatting across contexts', async () => {
+    const content = await renderMarkdownToReact(
+      `Nested ***bolditalic***, **bold _inner_**, _italic **inner**_, *\`italic code\`*, **\`bold code\`**, ~~**bold del**~~.
+
+Links **[bold link](https://a.com)**, *[italic link](https://a.com)*, **[[second-note|bold wiki]]**.
+
+> Quote with **bold**, *italic*, \`code\`, ~~del~~ and [link](https://a.com).
+
+| \`code\` | *italic* | **bold** |
+| --- | --- | --- |
+| a | ~~del~~ | ***bi*** |
+`,
+      linkMaps,
+    );
+
+    const { container } = render(<>{content}</>);
+
+    // 중첩 강조
+    expect(container.querySelector('em > strong')).toHaveTextContent('bolditalic');
+    expect(container.querySelector('strong > em')).toBeInTheDocument();
+    expect(container.querySelector('em > code')).toHaveTextContent('italic code');
+    expect(container.querySelector('strong > code')).toHaveTextContent('bold code');
+    expect(container.querySelector('del > strong')).toHaveTextContent('bold del');
+
+    // 링크/위키링크 강조
+    expect(container.querySelector('strong > a[href="https://a.com"]')).toHaveTextContent(
+      'bold link',
+    );
+    expect(container.querySelector('em > a[href="https://a.com"]')).toHaveTextContent(
+      'italic link',
+    );
+    expect(container.querySelector('strong > a.wiki-link')).toHaveTextContent('bold wiki');
+
+    // blockquote 내부 강조가 실제로 렌더됨 (CSS로 죽지 않도록 DOM 존재 보장)
+    const blockquote = container.querySelector('blockquote');
+    expect(blockquote?.querySelector('em')).toHaveTextContent('italic');
+    expect(blockquote?.querySelector('strong')).toHaveTextContent('bold');
+    expect(blockquote?.querySelector('del')).toHaveTextContent('del');
+    expect(blockquote?.querySelector('code')).toHaveTextContent('code');
+
+    // 표 셀 강조
+    const cells = container.querySelectorAll('tbody td');
+    expect(cells[1].querySelector('del')).toHaveTextContent('del');
+    expect(cells[2].querySelector('em > strong')).toHaveTextContent('bi');
   });
 
   it('renders only safe link schemes and strips raw HTML', async () => {

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -82,7 +82,9 @@ flowchart TD
         node => node.textContent,
       ),
     ).toContain("k'");
-    expect(container.querySelector('figure .mermaid')).toHaveTextContent('flowchart TD');
+    // 다이어그램 SVG는 클라이언트에서 Shadow DOM에 렌더되므로, 여기서는 mermaid
+    // 컨테이너가 존재하는지만 확인합니다(소스 텍스트를 라이트 DOM에 남기지 않음).
+    expect(container.querySelector('figure.mermaid-figure .mermaid')).toBeInTheDocument();
     expect(screen.getByAltText('Fixture image')).toBeInTheDocument();
 
     const code = container.querySelector('pre code');

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { extractTableOfContentsFromMarkdown, renderMarkdownToReact } from '@/libs/content';
 
@@ -249,6 +249,70 @@ flowchart TD
     expect(oversized).toHaveStyle({ width: '45rem', height: '25.3125rem' });
     expect(container.querySelectorAll('.markdown-image[data-sized="true"]')).toHaveLength(5);
     expect(screen.queryByText(/320x180|width=160|480x270|1200x675/)).not.toBeInTheDocument();
+  });
+
+  it('wraps code blocks with a language label and copy button', async () => {
+    const content = await renderMarkdownToReact(
+      `\`\`\`yaml
+name: Contents Sync
+on:
+  push:
+    branches:
+      - main
+\`\`\`
+`,
+    );
+
+    const { container } = render(<>{content}</>);
+    const codeBlock = container.querySelector('.code-block');
+
+    expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock).toHaveAttribute('data-language', 'yaml');
+    expect(container.querySelector('.code-block-language')).toHaveTextContent('YAML');
+    expect(container.querySelector('.code-block-copy')).toBeInTheDocument();
+    expect(container.querySelector('.code-block-content pre code')).toHaveTextContent(
+      'Contents Sync',
+    );
+    // 짧은 블록은 접기 토글을 노출하지 않습니다.
+    expect(container.querySelector('.code-block-toggle')).not.toBeInTheDocument();
+  });
+
+  it('shows a collapse toggle for long code blocks and copies the source', async () => {
+    const lines = Array.from({ length: 24 }, (_, index) => `const line${index} = ${index};`);
+    const content = await renderMarkdownToReact(`\`\`\`ts\n${lines.join('\n')}\n\`\`\`\n`);
+
+    const { container } = render(<>{content}</>);
+
+    expect(container.querySelector('.code-block-language')).toHaveTextContent('TypeScript');
+    const toggle = container.querySelector('.code-block-toggle');
+    expect(toggle).toBeInTheDocument();
+    expect(container.querySelector('.code-block-content')).toHaveAttribute(
+      'data-collapsed',
+      'true',
+    );
+
+    fireEvent.click(toggle as Element);
+    expect(container.querySelector('.code-block-content')).not.toHaveAttribute('data-collapsed');
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    fireEvent.click(container.querySelector('.code-block-copy') as Element);
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('const line0 = 0;'));
+  });
+
+  it('renders inline markdown emphasis inside image captions', async () => {
+    const content = await renderMarkdownToReact(
+      `![*italic* and **bold** caption](/content/posts/published-note/assets/diagram.svg)
+`,
+    );
+
+    const { container } = render(<>{content}</>);
+    const caption = container.querySelector('.markdown-image > span:last-of-type');
+
+    expect(caption?.querySelector('em')).toHaveTextContent('italic');
+    expect(caption?.querySelector('strong')).toHaveTextContent('bold');
+    // 원본 마크다운 별표가 캡션에 그대로 노출되면 안 됩니다.
+    expect(caption?.textContent).not.toContain('*');
   });
 
   it('renders only safe link schemes and strips raw HTML', async () => {

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -326,6 +326,18 @@ on:
     expect(caption?.textContent).not.toContain('*');
   });
 
+  it('uses the caption text for the accessibility label when alt is empty', async () => {
+    const content = await renderMarkdownToReact(
+      `![](/content/posts/published-note/assets/diagram.svg "그림 설명 캡션")`,
+      linkMaps,
+    );
+
+    render(<>{content}</>);
+
+    // alt가 비어 있어도 캡션 텍스트가 접근성 라벨에 반영되어야 합니다('이미지' 폴백 금지).
+    expect(screen.getByRole('button', { name: '이미지 확대: 그림 설명 캡션' })).toBeInTheDocument();
+  });
+
   it('renders composite inline formatting across contexts', async () => {
     const content = await renderMarkdownToReact(
       `Nested ***bolditalic***, **bold _inner_**, _italic **inner**_, *\`italic code\`*, **\`bold code\`**, ~~**bold del**~~.

--- a/src/components/templates/PostTemplate/PostTemplate.test.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.test.tsx
@@ -406,7 +406,7 @@ describe('PostTemplate', () => {
       const { container } = render(<PostTemplate {...defaultProps} />);
 
       const contentContainer = container.querySelector('div');
-      expect(contentContainer).toHaveClass('w-full', 'max-w-[1024px]', 'mx-auto', 'my-20', 'px-3');
+      expect(contentContainer).toHaveClass('w-full', 'max-w-[768px]', 'mx-auto', 'my-20', 'px-3');
 
       const mainElement = container.querySelector('main');
       expect(mainElement).toHaveClass('flex-1');

--- a/src/components/templates/PostTemplate/PostTemplate.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.tsx
@@ -99,7 +99,7 @@ export interface PostTemplateProps {
  * 3. PostNavigator - 이전글/다음글 네비게이션
  * 4. RelatedPosts - 관련 포스트 목록
  *
- * 최대 크기: 1024px
+ * 최대 크기: xl 이상 1024px(본문 768px + ToC 256px), 이하 768px
  */
 export const PostTemplate = ({
   post,
@@ -119,37 +119,37 @@ export const PostTemplate = ({
   className = '',
   tableOfContents = [],
 }: PostTemplateProps) => {
-  // 기본 컨테이너 스타일 - xl 이상에서는 1280px (PostBody 1024px + ToC 256px), 이하에서는 1024px
+  // 기본 컨테이너 스타일 - xl 이상에서는 1024px (PostBody 768px + ToC 256px), 이하에서는 768px
   const containerStyles = `
     min-h-screen w-full mx-auto my-20 px-3
-    max-w-[1024px] xl:max-w-[1280px]
+    max-w-[768px] xl:max-w-[1024px]
   `;
 
   return (
     <div className={`${containerStyles} ${className}`}>
       <main className="flex-1">
-        {/* Post Header Section - 1024px 유지 */}
-        <section className="mt-12 mb-6 max-w-[1024px]">
+        {/* Post Header Section - 768px 유지 */}
+        <section className="mt-12 mb-6 max-w-[768px]">
           <PostHeader {...post} onCategoryClick={onCategoryClick} onTagClick={onTagClick} />
         </section>
 
         {/* LLM 번역 고지 - en/ja 번역 포스트 상단에만 표시 */}
         {lang !== DEFAULT_POST_LANG && (
-          <section className="mb-6 max-w-[1024px]">
+          <section className="mb-6 max-w-[768px]">
             <TranslationNotice lang={lang} originalHref={createBlogPostHref(post)} />
           </section>
         )}
 
-        {/* Post Body Section - xl 이상에서는 PostBody(1024px) + ToC(256px) */}
+        {/* Post Body Section - xl 이상에서는 PostBody(768px) + ToC(256px) */}
         <section className="mb-12">
           {/* TableOfContents - xl 이하에서는 PostBody 위에 표시 */}
-          <div className="xl:hidden max-w-[1024px]">
+          <div className="xl:hidden max-w-[768px]">
             <TableOfContents items={tableOfContents} />
           </div>
 
           <div className="xl:flex">
-            {/* PostBody - 1024px 고정 크기 유지 */}
-            <div className="w-full xl:w-[1024px] xl:flex-shrink-0">
+            {/* PostBody - 768px 고정 크기 유지 */}
+            <div className="w-full xl:w-[768px] xl:flex-shrink-0">
               <PostBody markdown={markdown} linkMaps={linkMaps} lang={lang} />
             </div>
 
@@ -162,16 +162,16 @@ export const PostTemplate = ({
           </div>
         </section>
 
-        {/* Post Navigation Section - 1024px 유지 */}
+        {/* Post Navigation Section - 768px 유지 */}
         {(prevPost ?? nextPost) && (
-          <section className="mb-12 max-w-[1024px]">
+          <section className="mb-12 max-w-[768px]">
             <PostNavigator prevPost={prevPost} nextPost={nextPost} />
           </section>
         )}
 
-        {/* Related Posts Section - 1024px 유지 */}
+        {/* Related Posts Section - 768px 유지 */}
         {showRelatedPosts && relatedPosts.length > 0 && (
-          <section data-section="related-posts" className="max-w-[1024px]">
+          <section data-section="related-posts" className="max-w-[768px]">
             <RelatedPosts
               posts={relatedPosts}
               currentPostId={post.id}
@@ -187,8 +187,8 @@ export const PostTemplate = ({
           </section>
         )}
 
-        {/* Comments Section - 1024px 유지 */}
-        <section className="mb-12 max-w-[1024px]">
+        {/* Comments Section - 768px 유지 */}
+        <section className="mb-12 max-w-[768px]">
           <PostComments term={post.slug} />
         </section>
       </main>

--- a/src/components/templates/PostTemplate/PostTemplate.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.tsx
@@ -130,7 +130,12 @@ export const PostTemplate = ({
       <main className="flex-1">
         {/* Post Header Section - 768px 유지 */}
         <section className="mt-12 mb-6 max-w-[768px]">
-          <PostHeader {...post} onCategoryClick={onCategoryClick} onTagClick={onTagClick} />
+          <PostHeader
+            {...post}
+            lang={lang}
+            onCategoryClick={onCategoryClick}
+            onTagClick={onTagClick}
+          />
         </section>
 
         {/* LLM 번역 고지 - en/ja 번역 포스트 상단에만 표시 */}

--- a/src/components/ui/blog/CodeBlock/CodeBlock.tsx
+++ b/src/components/ui/blog/CodeBlock/CodeBlock.tsx
@@ -2,7 +2,7 @@
 
 import { Check, ChevronDown, Copy } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang } from '@/types/blog';
@@ -117,10 +117,20 @@ export function CodeBlock({
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+  const copyTimerRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
 
   const text = UI_TEXT[lang] ?? UI_TEXT[DEFAULT_POST_LANG];
   const collapsible = lineCount > COLLAPSE_LINE_THRESHOLD;
   const showCollapsed = collapsible && !expanded;
+
+  // 언마운트 시 예약된 "복사됨" 리셋 타이머를 정리합니다.
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) {
+        globalThis.clearTimeout(copyTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleCopy = async () => {
     const code = contentRef.current?.querySelector('code')?.textContent ?? '';
@@ -131,7 +141,10 @@ export function CodeBlock({
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      globalThis.setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current) {
+        globalThis.clearTimeout(copyTimerRef.current);
+      }
+      copyTimerRef.current = globalThis.setTimeout(() => setCopied(false), 2000);
     } catch {
       // 클립보드 권한이 없거나 실패한 경우 조용히 무시합니다.
     }

--- a/src/components/ui/blog/CodeBlock/CodeBlock.tsx
+++ b/src/components/ui/blog/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { Check, ChevronDown, Copy } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useRef, useState } from 'react';
+
+import { DEFAULT_POST_LANG } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+
+/**
+ * 코드 블록이 이 줄 수를 넘으면 접기(collapse) UI를 노출합니다.
+ */
+const COLLAPSE_LINE_THRESHOLD = 16;
+
+/**
+ * `data-language` 값 → 사람이 읽기 좋은 표기. 없으면 대문자로 폴백합니다.
+ */
+const LANGUAGE_LABELS: Record<string, string> = {
+  js: 'JavaScript',
+  javascript: 'JavaScript',
+  jsx: 'JSX',
+  ts: 'TypeScript',
+  typescript: 'TypeScript',
+  tsx: 'TSX',
+  json: 'JSON',
+  jsonc: 'JSONC',
+  yaml: 'YAML',
+  yml: 'YAML',
+  toml: 'TOML',
+  bash: 'Bash',
+  sh: 'Shell',
+  shell: 'Shell',
+  shellscript: 'Shell',
+  zsh: 'Zsh',
+  python: 'Python',
+  py: 'Python',
+  go: 'Go',
+  rust: 'Rust',
+  rs: 'Rust',
+  java: 'Java',
+  kotlin: 'Kotlin',
+  kt: 'Kotlin',
+  c: 'C',
+  cpp: 'C++',
+  'c++': 'C++',
+  cs: 'C#',
+  csharp: 'C#',
+  ruby: 'Ruby',
+  rb: 'Ruby',
+  php: 'PHP',
+  swift: 'Swift',
+  html: 'HTML',
+  css: 'CSS',
+  scss: 'SCSS',
+  sass: 'Sass',
+  sql: 'SQL',
+  graphql: 'GraphQL',
+  gql: 'GraphQL',
+  md: 'Markdown',
+  markdown: 'Markdown',
+  mdx: 'MDX',
+  dockerfile: 'Dockerfile',
+  docker: 'Dockerfile',
+  diff: 'Diff',
+  text: 'Text',
+  txt: 'Text',
+  plaintext: 'Text',
+};
+
+function languageLabel(language?: string): string {
+  if (!language) {
+    return 'Text';
+  }
+
+  const key = language.toLowerCase();
+  return LANGUAGE_LABELS[key] ?? language.toUpperCase();
+}
+
+const UI_TEXT: Record<
+  PostLang,
+  { copy: string; copied: string; expand: string; collapse: string }
+> = {
+  kr: { copy: '복사', copied: '복사됨', expand: '더 보기', collapse: '접기' },
+  en: { copy: 'Copy', copied: 'Copied', expand: 'Show more', collapse: 'Show less' },
+  ja: { copy: 'コピー', copied: 'コピー済み', expand: 'もっと見る', collapse: '折りたたむ' },
+};
+
+export interface CodeBlockProps {
+  /**
+   * `data-language` 원본 값 (예: `yaml`, `ts`).
+   */
+  language?: string;
+  /**
+   * 하이라이트된 코드의 줄 수. 접기 노출 여부를 결정합니다.
+   */
+  lineCount?: number;
+  /**
+   * UI 라벨 로컬라이즈용 렌더 언어.
+   */
+  lang?: PostLang;
+  /**
+   * rehype-pretty-code가 생성한 `<pre><code>` 트리.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Markdown 코드 블록을 언어 라벨 · 복사 버튼 · 긴 블록 접기 기능과 함께 렌더링합니다.
+ * 하이라이팅 결과(children)는 그대로 감싸고, 부가 chrome만 덧씌웁니다.
+ */
+export function CodeBlock({
+  language,
+  lineCount = 0,
+  lang = DEFAULT_POST_LANG,
+  children,
+}: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const text = UI_TEXT[lang] ?? UI_TEXT[DEFAULT_POST_LANG];
+  const collapsible = lineCount > COLLAPSE_LINE_THRESHOLD;
+  const showCollapsed = collapsible && !expanded;
+
+  const handleCopy = async () => {
+    const code = contentRef.current?.querySelector('code')?.textContent ?? '';
+    if (!code) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      globalThis.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // 클립보드 권한이 없거나 실패한 경우 조용히 무시합니다.
+    }
+  };
+
+  return (
+    <div className="code-block" data-language={language}>
+      <div className="code-block-header">
+        <span className="code-block-language">{languageLabel(language)}</span>
+        <button
+          type="button"
+          className="code-block-copy"
+          data-copied={copied ? 'true' : undefined}
+          onClick={handleCopy}
+          aria-label={copied ? text.copied : text.copy}
+          title={copied ? text.copied : text.copy}
+        >
+          {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+        </button>
+      </div>
+      <div
+        ref={contentRef}
+        className="code-block-content"
+        data-collapsed={showCollapsed ? 'true' : undefined}
+      >
+        {children}
+      </div>
+      {collapsible && (
+        <button
+          type="button"
+          className="code-block-toggle"
+          onClick={() => setExpanded(value => !value)}
+          aria-expanded={expanded}
+        >
+          <ChevronDown
+            className="code-block-toggle-icon"
+            data-expanded={expanded ? 'true' : undefined}
+            aria-hidden="true"
+          />
+          <span>{expanded ? text.collapse : text.expand}</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/blog/CodeBlock/index.tsx
+++ b/src/components/ui/blog/CodeBlock/index.tsx
@@ -1,0 +1,1 @@
+export * from './CodeBlock';

--- a/src/components/ui/blog/MarkdownImageLightbox/MarkdownImageLightbox.tsx
+++ b/src/components/ui/blog/MarkdownImageLightbox/MarkdownImageLightbox.tsx
@@ -27,7 +27,9 @@ export function MarkdownImageLightbox({
   sized,
 }: MarkdownImageLightboxProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const label = alt || '이미지';
+  // 캡션이 ReactNode로 확장되어, 문자열 캡션일 때만 접근성 라벨 폴백으로 사용합니다.
+  const captionText = typeof caption === 'string' ? caption : undefined;
+  const label = alt || captionText || '이미지';
   const lightboxImageStyle = {
     '--markdown-image-aspect-ratio': String(width / height),
   } as CSSProperties;

--- a/src/components/ui/blog/MarkdownImageLightbox/MarkdownImageLightbox.tsx
+++ b/src/components/ui/blog/MarkdownImageLightbox/MarkdownImageLightbox.tsx
@@ -2,7 +2,7 @@
 
 import { Maximize2, X } from 'lucide-react';
 import Image from 'next/image';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
 interface MarkdownImageLightboxProps {
@@ -12,7 +12,7 @@ interface MarkdownImageLightboxProps {
   height: number;
   className: string;
   style?: CSSProperties;
-  caption?: string;
+  caption?: ReactNode;
   sized?: boolean;
 }
 
@@ -27,7 +27,7 @@ export function MarkdownImageLightbox({
   sized,
 }: MarkdownImageLightboxProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const label = alt || caption || '이미지';
+  const label = alt || '이미지';
   const lightboxImageStyle = {
     '--markdown-image-aspect-ratio': String(width / height),
   } as CSSProperties;

--- a/src/components/ui/blog/MarkdownImageLightbox/MarkdownImageLightbox.tsx
+++ b/src/components/ui/blog/MarkdownImageLightbox/MarkdownImageLightbox.tsx
@@ -13,6 +13,11 @@ interface MarkdownImageLightboxProps {
   className: string;
   style?: CSSProperties;
   caption?: ReactNode;
+  /**
+   * 접근성 라벨 폴백용 순수 텍스트. caption이 ReactNode여도 aria-label에 캡션 텍스트를
+   * 반영하기 위해 별도로 받습니다.
+   */
+  captionText?: string;
   sized?: boolean;
 }
 
@@ -24,12 +29,14 @@ export function MarkdownImageLightbox({
   className,
   style,
   caption,
+  captionText,
   sized,
 }: MarkdownImageLightboxProps) {
   const [isOpen, setIsOpen] = useState(false);
-  // 캡션이 ReactNode로 확장되어, 문자열 캡션일 때만 접근성 라벨 폴백으로 사용합니다.
-  const captionText = typeof caption === 'string' ? caption : undefined;
-  const label = alt || captionText || '이미지';
+  // 캡션이 ReactNode여도 순수 텍스트(captionText)를 폴백으로 써서, alt가 비어도
+  // 접근성 라벨에 캡션 내용이 반영되도록 합니다. 문자열 캡션도 폴백으로 허용합니다.
+  const captionFallback = captionText ?? (typeof caption === 'string' ? caption : undefined);
+  const label = alt || captionFallback || '이미지';
   const lightboxImageStyle = {
     '--markdown-image-aspect-ratio': String(width / height),
   } as CSSProperties;

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -22,11 +22,17 @@ export function Mermaid({ code = '' }: MermaidProps) {
       try {
         const mermaid = (await import('mermaid')).default;
         // 사이트 테마를 강제하지 않습니다. 다이어그램이 %%{init}%%/classDef로 색·폰트를
-        // 정의했으면 그대로 존중하고(override 금지), 정의가 없으면 mermaid 기본 테마를
-        // 씁니다. antiscript는 스크립트만 제거하고 htmlLabels(라벨 color, <br/>)를 허용합니다.
+        // 정의했으면 그대로 존중하고(override 금지), 정의가 없으면 mermaid 기본 테마를 씁니다.
+        //
+        // htmlLabels를 켜야 라벨이 실제 HTML로 레이아웃되어 `<br/>` 줄바꿈, 자동 줄바꿈,
+        // 커스텀 폰트(Pretendard) 폭이 정확히 잡힙니다. SVG text 모드(strict/antiscript)는
+        // `<br/>`를 무시하고 폰트 폭 계산이 어긋나 마지막 글자가 잘립니다.
+        // 콘텐츠는 first-party KB라 loose(htmlLabels 허용)가 안전합니다.
         mermaid.initialize({
           startOnLoad: false,
-          securityLevel: 'antiscript',
+          securityLevel: 'loose',
+          htmlLabels: true,
+          flowchart: { htmlLabels: true },
         });
 
         ref.current.removeAttribute('data-processed');

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -8,35 +8,52 @@ export interface MermaidProps {
 
 export function Mermaid({ code = '' }: MermaidProps) {
   const id = useId().replace(/:/g, '');
-  const ref = useRef<HTMLDivElement>(null);
+  const hostRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
     async function renderDiagram() {
-      if (!ref.current || !code.trim()) {
+      const host = hostRef.current;
+      if (!host || !code.trim()) {
         return;
       }
 
       try {
         const mermaid = (await import('mermaid')).default;
-        // mermaid 기본값만 사용합니다. 사이트 테마/색을 일절 주입(override)하지 않고,
-        // 다이어그램이 %%{init}%%/classDef로 정의한 색은 mermaid가 처리하는 대로 둡니다.
+        // mermaid 기본값만 사용합니다(사이트 테마/색 주입 없음). 다이어그램이
+        // %%{init}%%/classDef로 정의한 색만 그대로 반영됩니다.
         //
-        // 예외적으로 securityLevel: 'loose'로 htmlLabels만 켭니다. 이는 색 override가
-        // 아니라 렌더링 방식입니다. 이게 없으면 `<br/>` 줄바꿈이 사라지고 커스텀 폰트
-        // 폭 계산이 어긋나 라벨 끝 글자가 잘립니다. 콘텐츠는 first-party KB라 안전합니다.
+        // securityLevel: 'antiscript' — htmlLabels(<br/>·자동 줄바꿈·폰트 폭 정확)를
+        // 허용하되 스크립트는 제거해 'loose'보다 XSS에 안전합니다. 추가로 아래에서 결과를
+        // Shadow DOM에 넣어 페이지와도 격리합니다.
         mermaid.initialize({
           startOnLoad: false,
-          securityLevel: 'loose',
+          securityLevel: 'antiscript',
           htmlLabels: true,
           flowchart: { htmlLabels: true },
         });
 
-        ref.current.removeAttribute('data-processed');
-        ref.current.textContent = code;
-        await mermaid.run({ nodes: [ref.current] });
+        // 커스텀 폰트가 로드된 뒤 렌더해야 라벨 폭 계산이 어긋나 글자가 잘리지 않습니다.
+        if (typeof document !== 'undefined' && document.fonts?.ready) {
+          try {
+            await document.fonts.ready;
+          } catch {
+            // 폰트 로드 상태를 확인할 수 없어도 렌더는 진행합니다.
+          }
+        }
+
+        const { svg } = await mermaid.render(`mermaid-svg-${id}`, code);
+        if (cancelled) {
+          return;
+        }
+
+        // Shadow DOM으로 페이지 CSS(globals의 p { color } 등)를 완전히 차단해, 다이어그램이
+        // mermaid 자체 스타일만 쓰도록 격리합니다(GitHub/VSCode 렌더러처럼). 이 격리가 없으면
+        // 본문 타이포가 라벨로 새어들어 색이 씻기거나 폭이 어긋나 글자가 잘립니다.
+        const shadow = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
+        shadow.innerHTML = `<style>:host{all:initial;display:block}svg{display:block;max-width:100%;height:auto;margin:0 auto}</style>${svg}`;
 
         if (!cancelled) {
           setError(null);
@@ -53,19 +70,19 @@ export function Mermaid({ code = '' }: MermaidProps) {
     return () => {
       cancelled = true;
     };
-  }, [code]);
+  }, [code, id]);
 
   if (!code.trim()) {
     return null;
   }
 
   return (
-    <figure className="my-6 overflow-x-auto rounded-lg border border-[color:var(--color-border)] bg-[color:var(--color-surface)] p-4">
-      <div id={`mermaid-${id}`} ref={ref} className="mermaid">
+    <figure className="mermaid-figure my-6 overflow-x-auto">
+      <div ref={hostRef} className="mermaid" role="img" aria-label="다이어그램">
         {code}
       </div>
       {error && (
-        <figcaption className="mt-3 text-sm text-[color:var(--color-text-secondary)]">
+        <figcaption className="mermaid-error mt-3 text-sm">
           Mermaid diagram could not be rendered.
         </figcaption>
       )}

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -106,14 +106,16 @@ export function Mermaid({ code = '', lang = DEFAULT_POST_LANG }: MermaidProps) {
 
   return (
     <figure className="mermaid-figure my-6 overflow-x-auto">
+      {/*
+        렌더 결과 SVG는 Shadow DOM에 삽입되므로 host는 빈 컨테이너로 둡니다. 여기에 code
+        텍스트를 자식으로 넣으면 렌더 성공 후에도 라이트 DOM에 소스가 중복 유지됩니다.
+      */}
       <div
         ref={hostRef}
         className="mermaid"
         role="img"
         aria-label={DIAGRAM_LABEL[lang] ?? DIAGRAM_LABEL[DEFAULT_POST_LANG]}
-      >
-        {code}
-      </div>
+      />
       {error && (
         <figcaption className="mermaid-error mt-3 text-sm">
           Mermaid diagram could not be rendered.

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -10,28 +10,6 @@ export function Mermaid({ code = '' }: MermaidProps) {
   const id = useId().replace(/:/g, '');
   const ref = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [theme, setTheme] = useState<'default' | 'dark'>('default');
-
-  useEffect(() => {
-    const readTheme = () =>
-      setTheme(document.documentElement.dataset.theme === 'dark' ? 'dark' : 'default');
-
-    readTheme();
-
-    if (!globalThis.MutationObserver) {
-      return undefined;
-    }
-
-    const observer = new globalThis.MutationObserver(readTheme);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    });
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -43,10 +21,12 @@ export function Mermaid({ code = '' }: MermaidProps) {
 
       try {
         const mermaid = (await import('mermaid')).default;
+        // 사이트 테마를 강제하지 않습니다. 다이어그램이 %%{init}%%/classDef로 색·폰트를
+        // 정의했으면 그대로 존중하고(override 금지), 정의가 없으면 mermaid 기본 테마를
+        // 씁니다. antiscript는 스크립트만 제거하고 htmlLabels(라벨 color, <br/>)를 허용합니다.
         mermaid.initialize({
           startOnLoad: false,
-          securityLevel: 'strict',
-          theme,
+          securityLevel: 'antiscript',
         });
 
         ref.current.removeAttribute('data-processed');
@@ -68,7 +48,7 @@ export function Mermaid({ code = '' }: MermaidProps) {
     return () => {
       cancelled = true;
     };
-  }, [code, theme]);
+  }, [code]);
 
   if (!code.trim()) {
     return null;

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -66,17 +66,22 @@ export function Mermaid({ code = '', lang = DEFAULT_POST_LANG }: MermaidProps) {
         // 페이지 CSS(globals의 p { color } 등)를 완전히 차단해, 다이어그램이 mermaid 자체
         // 스타일만 쓰도록 격리합니다(GitHub/VSCode 렌더러처럼). 격리가 없으면 본문 타이포가
         // 라벨로 새어들어 색이 씻기거나 폭이 어긋나 글자가 잘립니다.
+        // htmlLabels(<br>·foreignObject 내부 HTML)는 엄격 XML(image/svg+xml)에서 깨질 수
+        // 있어 관대한 text/html로 파싱합니다. 파싱 실패로 svg를 못 찾으면 조용히 빈
+        // 다이어그램을 남기지 않고 에러를 던져 아래 error UI가 뜨게 합니다.
         const parsedSvg = new globalThis.DOMParser()
           .parseFromString(svg, 'text/html')
           .body.querySelector('svg');
+        if (!parsedSvg) {
+          throw new Error('Mermaid SVG could not be parsed');
+        }
+
         const shadow = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
         const style = document.createElement('style');
         style.textContent =
           ':host{all:initial;display:block}svg{display:block;max-width:100%;height:auto;margin:0 auto}';
         shadow.replaceChildren(style);
-        if (parsedSvg) {
-          shadow.append(document.importNode(parsedSvg, true));
-        }
+        shadow.append(document.importNode(parsedSvg, true));
 
         if (!cancelled) {
           setError(null);

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -2,11 +2,24 @@
 
 import { useEffect, useId, useRef, useState } from 'react';
 
+import { DEFAULT_POST_LANG } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+
 export interface MermaidProps {
   code?: string;
+  /**
+   * 접근성 라벨 로컬라이즈용 렌더 언어.
+   */
+  lang?: PostLang;
 }
 
-export function Mermaid({ code = '' }: MermaidProps) {
+const DIAGRAM_LABEL: Record<PostLang, string> = {
+  kr: '다이어그램',
+  en: 'Diagram',
+  ja: '図',
+};
+
+export function Mermaid({ code = '', lang = DEFAULT_POST_LANG }: MermaidProps) {
   const id = useId().replace(/:/g, '');
   const hostRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
@@ -26,8 +39,7 @@ export function Mermaid({ code = '' }: MermaidProps) {
         // %%{init}%%/classDef로 정의한 색만 그대로 반영됩니다.
         //
         // securityLevel: 'antiscript' — htmlLabels(<br/>·자동 줄바꿈·폰트 폭 정확)를
-        // 허용하되 스크립트는 제거해 'loose'보다 XSS에 안전합니다. 추가로 아래에서 결과를
-        // Shadow DOM에 넣어 페이지와도 격리합니다.
+        // 허용하되 스크립트는 제거해 'loose'보다 XSS에 안전합니다.
         mermaid.initialize({
           startOnLoad: false,
           securityLevel: 'antiscript',
@@ -49,11 +61,22 @@ export function Mermaid({ code = '' }: MermaidProps) {
           return;
         }
 
-        // Shadow DOM으로 페이지 CSS(globals의 p { color } 등)를 완전히 차단해, 다이어그램이
-        // mermaid 자체 스타일만 쓰도록 격리합니다(GitHub/VSCode 렌더러처럼). 이 격리가 없으면
-        // 본문 타이포가 라벨로 새어들어 색이 씻기거나 폭이 어긋나 글자가 잘립니다.
+        // 문자열 innerHTML 주입 대신 DOMParser로 SVG를 inert 문서에서 파싱해 노드로
+        // 삽입합니다(스크립트 미실행 + DOM 클로버링 리스크 감소). 추가로 Shadow DOM으로
+        // 페이지 CSS(globals의 p { color } 등)를 완전히 차단해, 다이어그램이 mermaid 자체
+        // 스타일만 쓰도록 격리합니다(GitHub/VSCode 렌더러처럼). 격리가 없으면 본문 타이포가
+        // 라벨로 새어들어 색이 씻기거나 폭이 어긋나 글자가 잘립니다.
+        const parsedSvg = new globalThis.DOMParser()
+          .parseFromString(svg, 'text/html')
+          .body.querySelector('svg');
         const shadow = host.shadowRoot ?? host.attachShadow({ mode: 'open' });
-        shadow.innerHTML = `<style>:host{all:initial;display:block}svg{display:block;max-width:100%;height:auto;margin:0 auto}</style>${svg}`;
+        const style = document.createElement('style');
+        style.textContent =
+          ':host{all:initial;display:block}svg{display:block;max-width:100%;height:auto;margin:0 auto}';
+        shadow.replaceChildren(style);
+        if (parsedSvg) {
+          shadow.append(document.importNode(parsedSvg, true));
+        }
 
         if (!cancelled) {
           setError(null);
@@ -78,7 +101,12 @@ export function Mermaid({ code = '' }: MermaidProps) {
 
   return (
     <figure className="mermaid-figure my-6 overflow-x-auto">
-      <div ref={hostRef} className="mermaid" role="img" aria-label="다이어그램">
+      <div
+        ref={hostRef}
+        className="mermaid"
+        role="img"
+        aria-label={DIAGRAM_LABEL[lang] ?? DIAGRAM_LABEL[DEFAULT_POST_LANG]}
+      >
         {code}
       </div>
       {error && (

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -19,6 +19,12 @@ const DIAGRAM_LABEL: Record<PostLang, string> = {
   ja: '図',
 };
 
+const ERROR_LABEL: Record<PostLang, string> = {
+  kr: '다이어그램을 렌더링할 수 없습니다.',
+  en: 'Mermaid diagram could not be rendered.',
+  ja: '図をレンダリングできませんでした。',
+};
+
 export function Mermaid({ code = '', lang = DEFAULT_POST_LANG }: MermaidProps) {
   const id = useId().replace(/:/g, '');
   const hostRef = useRef<HTMLDivElement>(null);
@@ -118,7 +124,7 @@ export function Mermaid({ code = '', lang = DEFAULT_POST_LANG }: MermaidProps) {
       />
       {error && (
         <figcaption className="mermaid-error mt-3 text-sm">
-          Mermaid diagram could not be rendered.
+          {ERROR_LABEL[lang] ?? ERROR_LABEL[DEFAULT_POST_LANG]}
         </figcaption>
       )}
     </figure>

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -6,10 +6,63 @@ export interface MermaidProps {
   code?: string;
 }
 
+function readIsDark(): boolean {
+  return document.documentElement.dataset.theme === 'dark';
+}
+
+/**
+ * 색 지정이 없는 다이어그램이 PostBody 톤(폰트색·라인·표면)을 따르도록 하는
+ * themeVariables 폴백입니다. 다이어그램이 %%{init}%%/classDef로 색을 지정하면
+ * 그 값이 이 폴백을 덮어써서 그대로 유지됩니다(override 금지).
+ */
+function postBodyThemeVariables(isDark: boolean) {
+  const fg = isDark ? '#ffffff' : '#111111';
+  const surface = isDark ? '#1f1f1e' : '#f5f5f3';
+  const border = isDark ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.24)';
+  const line = isDark ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.45)';
+
+  return {
+    darkMode: isDark,
+    fontFamily: 'Pretendard, sans-serif',
+    background: 'transparent',
+    primaryColor: surface,
+    secondaryColor: surface,
+    tertiaryColor: surface,
+    primaryTextColor: fg,
+    secondaryTextColor: fg,
+    tertiaryTextColor: fg,
+    primaryBorderColor: border,
+    secondaryBorderColor: border,
+    tertiaryBorderColor: border,
+    lineColor: line,
+    titleColor: fg,
+    nodeTextColor: fg,
+  };
+}
+
 export function Mermaid({ code = '' }: MermaidProps) {
   const id = useId().replace(/:/g, '');
   const ref = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isDark, setIsDark] = useState(false);
+
+  // 사이트 테마(data-theme)를 관찰해, 색 미지정 다이어그램의 폴백 색을 라이트/다크에
+  // 맞춥니다. 지정된 다이어그램은 자체 색을 쓰므로 이 값에 영향받지 않습니다.
+  useEffect(() => {
+    setIsDark(readIsDark());
+
+    if (!globalThis.MutationObserver) {
+      return undefined;
+    }
+
+    const observer = new globalThis.MutationObserver(() => setIsDark(readIsDark()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -21,18 +74,19 @@ export function Mermaid({ code = '' }: MermaidProps) {
 
       try {
         const mermaid = (await import('mermaid')).default;
-        // 사이트 테마를 강제하지 않습니다. 다이어그램이 %%{init}%%/classDef로 색·폰트를
-        // 정의했으면 그대로 존중하고(override 금지), 정의가 없으면 mermaid 기본 테마를 씁니다.
+        // 색 지정이 있으면 그대로(override 금지), 없으면 PostBody 톤(폰트색 등)을 반영합니다.
+        // theme:'base' + themeVariables 폴백으로 미지정 다이어그램을 사이트 테마에 맞추고,
+        // 다이어그램의 %%{init}%%/classDef 지정은 이 폴백을 덮어써 그대로 유지됩니다.
         //
-        // htmlLabels를 켜야 라벨이 실제 HTML로 레이아웃되어 `<br/>` 줄바꿈, 자동 줄바꿈,
-        // 커스텀 폰트(Pretendard) 폭이 정확히 잡힙니다. SVG text 모드(strict/antiscript)는
-        // `<br/>`를 무시하고 폰트 폭 계산이 어긋나 마지막 글자가 잘립니다.
-        // 콘텐츠는 first-party KB라 loose(htmlLabels 허용)가 안전합니다.
+        // htmlLabels를 켜야 라벨이 실제 HTML로 레이아웃되어 `<br/>` 줄바꿈·자동 줄바꿈·
+        // 커스텀 폰트(Pretendard) 폭이 정확합니다. 콘텐츠는 first-party KB라 loose가 안전합니다.
         mermaid.initialize({
           startOnLoad: false,
           securityLevel: 'loose',
           htmlLabels: true,
           flowchart: { htmlLabels: true },
+          theme: 'base',
+          themeVariables: postBodyThemeVariables(isDark),
         });
 
         ref.current.removeAttribute('data-processed');
@@ -54,7 +108,7 @@ export function Mermaid({ code = '' }: MermaidProps) {
     return () => {
       cancelled = true;
     };
-  }, [code]);
+  }, [code, isDark]);
 
   if (!code.trim()) {
     return null;

--- a/src/components/ui/blog/Mermaid/Mermaid.tsx
+++ b/src/components/ui/blog/Mermaid/Mermaid.tsx
@@ -6,63 +6,10 @@ export interface MermaidProps {
   code?: string;
 }
 
-function readIsDark(): boolean {
-  return document.documentElement.dataset.theme === 'dark';
-}
-
-/**
- * 색 지정이 없는 다이어그램이 PostBody 톤(폰트색·라인·표면)을 따르도록 하는
- * themeVariables 폴백입니다. 다이어그램이 %%{init}%%/classDef로 색을 지정하면
- * 그 값이 이 폴백을 덮어써서 그대로 유지됩니다(override 금지).
- */
-function postBodyThemeVariables(isDark: boolean) {
-  const fg = isDark ? '#ffffff' : '#111111';
-  const surface = isDark ? '#1f1f1e' : '#f5f5f3';
-  const border = isDark ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.24)';
-  const line = isDark ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.45)';
-
-  return {
-    darkMode: isDark,
-    fontFamily: 'Pretendard, sans-serif',
-    background: 'transparent',
-    primaryColor: surface,
-    secondaryColor: surface,
-    tertiaryColor: surface,
-    primaryTextColor: fg,
-    secondaryTextColor: fg,
-    tertiaryTextColor: fg,
-    primaryBorderColor: border,
-    secondaryBorderColor: border,
-    tertiaryBorderColor: border,
-    lineColor: line,
-    titleColor: fg,
-    nodeTextColor: fg,
-  };
-}
-
 export function Mermaid({ code = '' }: MermaidProps) {
   const id = useId().replace(/:/g, '');
   const ref = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [isDark, setIsDark] = useState(false);
-
-  // 사이트 테마(data-theme)를 관찰해, 색 미지정 다이어그램의 폴백 색을 라이트/다크에
-  // 맞춥니다. 지정된 다이어그램은 자체 색을 쓰므로 이 값에 영향받지 않습니다.
-  useEffect(() => {
-    setIsDark(readIsDark());
-
-    if (!globalThis.MutationObserver) {
-      return undefined;
-    }
-
-    const observer = new globalThis.MutationObserver(() => setIsDark(readIsDark()));
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -74,19 +21,17 @@ export function Mermaid({ code = '' }: MermaidProps) {
 
       try {
         const mermaid = (await import('mermaid')).default;
-        // 색 지정이 있으면 그대로(override 금지), 없으면 PostBody 톤(폰트색 등)을 반영합니다.
-        // theme:'base' + themeVariables 폴백으로 미지정 다이어그램을 사이트 테마에 맞추고,
-        // 다이어그램의 %%{init}%%/classDef 지정은 이 폴백을 덮어써 그대로 유지됩니다.
+        // mermaid 기본값만 사용합니다. 사이트 테마/색을 일절 주입(override)하지 않고,
+        // 다이어그램이 %%{init}%%/classDef로 정의한 색은 mermaid가 처리하는 대로 둡니다.
         //
-        // htmlLabels를 켜야 라벨이 실제 HTML로 레이아웃되어 `<br/>` 줄바꿈·자동 줄바꿈·
-        // 커스텀 폰트(Pretendard) 폭이 정확합니다. 콘텐츠는 first-party KB라 loose가 안전합니다.
+        // 예외적으로 securityLevel: 'loose'로 htmlLabels만 켭니다. 이는 색 override가
+        // 아니라 렌더링 방식입니다. 이게 없으면 `<br/>` 줄바꿈이 사라지고 커스텀 폰트
+        // 폭 계산이 어긋나 라벨 끝 글자가 잘립니다. 콘텐츠는 first-party KB라 안전합니다.
         mermaid.initialize({
           startOnLoad: false,
           securityLevel: 'loose',
           htmlLabels: true,
           flowchart: { htmlLabels: true },
-          theme: 'base',
-          themeVariables: postBodyThemeVariables(isDark),
         });
 
         ref.current.removeAttribute('data-processed');
@@ -108,7 +53,7 @@ export function Mermaid({ code = '' }: MermaidProps) {
     return () => {
       cancelled = true;
     };
-  }, [code, isDark]);
+  }, [code]);
 
   if (!code.trim()) {
     return null;

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -102,7 +102,7 @@ export const PostCard = ({
             <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-              {`${readingTime} min read`}
+              {`${readingTime} min`}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -1,3 +1,4 @@
+import { Clock } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -30,6 +31,7 @@ export const PostCard = ({
   title,
   description,
   createdAt,
+  readingTime,
   category,
   tags,
   cover,
@@ -93,9 +95,16 @@ export const PostCard = ({
           </Heading>
         </div>
 
-        {/* 날짜 */}
-        <div className="mb-3 text-left">
+        {/* 날짜 · 읽기 시간 */}
+        <div className="mb-3 flex items-center gap-2 text-left">
           <Text fontFamily="maruBuri">{createdAt}</Text>
+          {readingTime ? (
+            <span className="flex items-center gap-1 text-(--color-text-secondary)">
+              <span aria-hidden="true">·</span>
+              <Clock aria-hidden="true" className="h-3.5 w-3.5" />
+              <Text fontFamily="maruBuri">{`${readingTime} min read`}</Text>
+            </span>
+          ) : null}
         </div>
 
         {/* 설명 */}

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -99,10 +99,10 @@ export const PostCard = ({
         <div className="mb-3 flex items-center gap-2 text-left">
           <Text fontFamily="maruBuri">{createdAt}</Text>
           {readingTime ? (
-            <span className="flex items-center gap-1 text-(--color-text-secondary)">
+            <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-              <Text fontFamily="maruBuri">{`${readingTime} min read`}</Text>
+              {`${readingTime} min read`}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -99,7 +99,7 @@ export const PostCard = ({
         <div className="mb-3 flex items-center gap-2 text-left">
           <Text fontFamily="maruBuri">{createdAt}</Text>
           {readingTime ? (
-            <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
+            <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text-secondary)]">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
               {`${readingTime} min`}

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -6,12 +6,18 @@ import React from 'react';
 import { LabelButton } from '@/components/ui/buttons/LabelButton';
 import { TagButton } from '@/components/ui/buttons/TagButton';
 import { Heading, Text } from '@/components/ui/typography';
-import { PostMeta } from '@/types/blog';
+import { DEFAULT_POST_LANG, PostMeta } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+import { formatReadingTime } from '@/utils/blog';
 
 /**
  * PostCard 컴포넌트 Props
  */
 export interface PostCardProps extends PostMeta {
+  /**
+   * 렌더 언어. 읽기 시간 표기 로컬라이즈에 사용합니다.
+   */
+  lang?: PostLang;
   /**
    * 추가 CSS 클래스
    */
@@ -32,6 +38,7 @@ export const PostCard = ({
   description,
   createdAt,
   readingTime,
+  lang = DEFAULT_POST_LANG,
   category,
   tags,
   cover,
@@ -102,7 +109,7 @@ export const PostCard = ({
             <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text-secondary)]">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-              {`${readingTime} min`}
+              {formatReadingTime(readingTime, lang)}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -101,7 +101,7 @@ export const PostHeader = ({
           <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
             <span aria-hidden="true">·</span>
             <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-            {`${readingTime} min read`}
+            {`${readingTime} min`}
           </span>
         ) : null}
       </div>

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -1,3 +1,4 @@
+import { Clock } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -35,6 +36,7 @@ export const PostHeader = ({
   title,
   description,
   createdAt,
+  readingTime,
   category,
   tags = [],
   cover,
@@ -92,9 +94,16 @@ export const PostHeader = ({
         <Heading level={1}>{title}</Heading>
       </div>
 
-      {/* 날짜 */}
-      <div className="mb-6">
+      {/* 날짜 · 읽기 시간 */}
+      <div className="mb-6 flex items-center gap-2">
         <Text fontFamily="maruBuri">{createdAt}</Text>
+        {readingTime ? (
+          <span className="flex items-center gap-1 text-(--color-text-secondary)">
+            <span aria-hidden="true">·</span>
+            <Clock aria-hidden="true" className="h-3.5 w-3.5" />
+            <Text fontFamily="maruBuri">{`${readingTime} min read`}</Text>
+          </span>
+        ) : null}
       </div>
 
       {/* 태그 목록 */}

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -98,10 +98,10 @@ export const PostHeader = ({
       <div className="mb-6 flex items-center gap-2">
         <Text fontFamily="maruBuri">{createdAt}</Text>
         {readingTime ? (
-          <span className="flex items-center gap-1 text-(--color-text-secondary)">
+          <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
             <span aria-hidden="true">·</span>
             <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-            <Text fontFamily="maruBuri">{`${readingTime} min read`}</Text>
+            {`${readingTime} min read`}
           </span>
         ) : null}
       </div>

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -6,10 +6,15 @@ import React from 'react';
 import { LabelButton } from '@/components/ui/buttons/LabelButton';
 import { TagButton } from '@/components/ui/buttons/TagButton';
 import { Heading, Text } from '@/components/ui/typography';
-import { PostMeta } from '@/types/blog';
-import { createBlogFilterHref } from '@/utils/blog';
+import { DEFAULT_POST_LANG, PostMeta } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+import { createBlogFilterHref, formatReadingTime } from '@/utils/blog';
 
 export interface PostHeaderProps extends Omit<PostMeta, 'href'> {
+  /**
+   * 렌더 언어. 읽기 시간 표기 로컬라이즈에 사용합니다.
+   */
+  lang?: PostLang;
   /**
    * 추가 CSS 클래스
    */
@@ -37,6 +42,7 @@ export const PostHeader = ({
   description,
   createdAt,
   readingTime,
+  lang = DEFAULT_POST_LANG,
   category,
   tags = [],
   cover,
@@ -101,7 +107,7 @@ export const PostHeader = ({
           <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text-secondary)]">
             <span aria-hidden="true">·</span>
             <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-            {`${readingTime} min`}
+            {formatReadingTime(readingTime, lang)}
           </span>
         ) : null}
       </div>

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -98,7 +98,7 @@ export const PostHeader = ({
       <div className="mb-6 flex items-center gap-2">
         <Text fontFamily="maruBuri">{createdAt}</Text>
         {readingTime ? (
-          <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
+          <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text-secondary)]">
             <span aria-hidden="true">·</span>
             <Clock aria-hidden="true" className="h-3.5 w-3.5" />
             {`${readingTime} min`}

--- a/src/components/ui/blog/PostRow/PostRow.tsx
+++ b/src/components/ui/blog/PostRow/PostRow.tsx
@@ -1,3 +1,4 @@
+import { Clock } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -37,6 +38,7 @@ export const PostRow = ({
   title,
   description,
   createdAt,
+  readingTime,
   category,
   tags,
   cover,
@@ -76,8 +78,17 @@ export const PostRow = ({
           {title}
         </Heading>
 
-        {/* 날짜 */}
-        <Text fontFamily="maruBuri">{createdAt}</Text>
+        {/* 날짜 · 읽기 시간 */}
+        <div className="flex items-center gap-2">
+          <Text fontFamily="maruBuri">{createdAt}</Text>
+          {readingTime ? (
+            <span className="flex items-center gap-1 text-(--color-text-secondary)">
+              <span aria-hidden="true">·</span>
+              <Clock aria-hidden="true" className="h-3.5 w-3.5" />
+              <Text fontFamily="maruBuri">{`${readingTime} min read`}</Text>
+            </span>
+          ) : null}
+        </div>
 
         {/* 설명 */}
         <Text

--- a/src/components/ui/blog/PostRow/PostRow.tsx
+++ b/src/components/ui/blog/PostRow/PostRow.tsx
@@ -85,7 +85,7 @@ export const PostRow = ({
             <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-              {`${readingTime} min read`}
+              {`${readingTime} min`}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostRow/PostRow.tsx
+++ b/src/components/ui/blog/PostRow/PostRow.tsx
@@ -82,10 +82,10 @@ export const PostRow = ({
         <div className="flex items-center gap-2">
           <Text fontFamily="maruBuri">{createdAt}</Text>
           {readingTime ? (
-            <span className="flex items-center gap-1 text-(--color-text-secondary)">
+            <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-              <Text fontFamily="maruBuri">{`${readingTime} min read`}</Text>
+              {`${readingTime} min read`}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostRow/PostRow.tsx
+++ b/src/components/ui/blog/PostRow/PostRow.tsx
@@ -6,12 +6,18 @@ import React from 'react';
 import { LabelButton } from '@/components/ui/buttons/LabelButton';
 import { TagButton } from '@/components/ui/buttons/TagButton';
 import { Heading, Text } from '@/components/ui/typography';
-import { PostMeta } from '@/types/blog';
+import { DEFAULT_POST_LANG, PostMeta } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+import { formatReadingTime } from '@/utils/blog';
 
 /**
  * PostRow 컴포넌트 Props
  */
 export interface PostRowProps extends PostMeta {
+  /**
+   * 렌더 언어. 읽기 시간 표기 로컬라이즈에 사용합니다.
+   */
+  lang?: PostLang;
   /**
    * 추가 CSS 클래스
    */
@@ -39,6 +45,7 @@ export const PostRow = ({
   description,
   createdAt,
   readingTime,
+  lang = DEFAULT_POST_LANG,
   category,
   tags,
   cover,
@@ -85,7 +92,7 @@ export const PostRow = ({
             <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text-secondary)]">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
-              {`${readingTime} min`}
+              {formatReadingTime(readingTime, lang)}
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostRow/PostRow.tsx
+++ b/src/components/ui/blog/PostRow/PostRow.tsx
@@ -82,7 +82,7 @@ export const PostRow = ({
         <div className="flex items-center gap-2">
           <Text fontFamily="maruBuri">{createdAt}</Text>
           {readingTime ? (
-            <span className="flex items-center gap-1 font-maruBuri text-(--color-text-secondary)">
+            <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text-secondary)]">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
               {`${readingTime} min`}

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -183,8 +183,9 @@ function restoreKbMarkdownSyntax(markdown: string): string {
       .replace(/\\\*(\[[^\]\n]+\]\([^)]+\))\\\*/g, '*$1*')
       .replace(/^> \\\[!(TIP|NOTE|WARNING|CAUTION|IMPORTANT)\]/gm, '> [!$1]')
       // 이미지 캡션(alt)에 보존한 강조/취소선/인라인 코드/math 마커의 이스케이프를 해제합니다.
+      // alt 안의 이스케이프된 `\]`도 그대로 통과시키도록 escaped 문자를 허용합니다.
       .replace(
-        /!\[([^\]]*)\]\(/g,
+        /!\[((?:\\.|[^\]\\])*)\]\(/g,
         (_full, alt: string) => `![${alt.replace(/\\([*_~`$])/g, '$1')}](`,
       )
   );
@@ -454,7 +455,8 @@ export function transformMarkdownForExport(
     const endOffset = image.position?.end?.offset;
     if (typeof startOffset === 'number' && typeof endOffset === 'number') {
       const rawImage = normalizedContent.slice(startOffset, endOffset);
-      const rawAltMatch = rawImage.match(/^!\[([^\]]*)\]\(/);
+      // 이스케이프된 `\]`가 alt에 있어도 잘리지 않도록 escaped 문자를 허용합니다.
+      const rawAltMatch = rawImage.match(/^!\[((?:\\.|[^\]\\])*)\]\(/);
       if (rawAltMatch) {
         image.alt = rawAltMatch[1];
       }

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -174,13 +174,20 @@ function removeUndefinedValues<T extends Record<string, unknown>>(data: T): Part
 }
 
 function restoreKbMarkdownSyntax(markdown: string): string {
-  return markdown
-    .replace(/\\\[\\\[/g, '[[')
-    .replace(/\\\*\\\*(\[\[[^\]\n]+\]\])\\\*\\\*/g, '**$1**')
-    .replace(/\\\*\\\*(\[[^\]\n]+\]\([^)]+\))\\\*\\\*/g, '**$1**')
-    .replace(/\\\*(\[\[[^\]\n]+\]\])\\\*/g, '*$1*')
-    .replace(/\\\*(\[[^\]\n]+\]\([^)]+\))\\\*/g, '*$1*')
-    .replace(/^> \\\[!(TIP|NOTE|WARNING|CAUTION|IMPORTANT)\]/gm, '> [!$1]');
+  return (
+    markdown
+      .replace(/\\\[\\\[/g, '[[')
+      .replace(/\\\*\\\*(\[\[[^\]\n]+\]\])\\\*\\\*/g, '**$1**')
+      .replace(/\\\*\\\*(\[[^\]\n]+\]\([^)]+\))\\\*\\\*/g, '**$1**')
+      .replace(/\\\*(\[\[[^\]\n]+\]\])\\\*/g, '*$1*')
+      .replace(/\\\*(\[[^\]\n]+\]\([^)]+\))\\\*/g, '*$1*')
+      .replace(/^> \\\[!(TIP|NOTE|WARNING|CAUTION|IMPORTANT)\]/gm, '> [!$1]')
+      // 이미지 캡션(alt)에 보존한 강조/취소선/인라인 코드/math 마커의 이스케이프를 해제합니다.
+      .replace(
+        /!\[([^\]]*)\]\(/g,
+        (_full, alt: string) => `![${alt.replace(/\\([*_~`$])/g, '$1')}](`,
+      )
+  );
 }
 
 function isReferencesHeading(node: RootContent): node is Heading {
@@ -439,6 +446,20 @@ export function transformMarkdownForExport(
     }
 
     const image = node as Image;
+
+    // mdast는 `![*강조*](url)`의 alt를 계산할 때 강조/취소선/math 마커를 제거하므로,
+    // 원본 소스에서 alt 부분을 그대로 되살려 캡션 서식이 export 결과에 남도록 합니다.
+    // (stringify가 마커를 이스케이프하면 restoreKbMarkdownSyntax가 다시 풀어냅니다.)
+    const startOffset = image.position?.start?.offset;
+    const endOffset = image.position?.end?.offset;
+    if (typeof startOffset === 'number' && typeof endOffset === 'number') {
+      const rawImage = normalizedContent.slice(startOffset, endOffset);
+      const rawAltMatch = rawImage.match(/^!\[([^\]]*)\]\(/);
+      if (rawAltMatch) {
+        image.alt = rawAltMatch[1];
+      }
+    }
+
     if (!isLocalAssetUrl(image.url)) {
       return;
     }

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -18,6 +18,7 @@ import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang } from '@/types/blog';
 
 import { deriveCategoryFromPath } from './category';
+import { extractImageAltAtStart, unescapeMarkersInImageAlts } from './imageAlt';
 import { normalizeMarkdownImageSizeSyntax } from './imageDimensions';
 import { parseInlineMarkdownChildren } from './inlineMarkdown';
 import { resolveMarkdownLink } from './linkResolver';
@@ -174,21 +175,17 @@ function removeUndefinedValues<T extends Record<string, unknown>>(data: T): Part
 }
 
 function restoreKbMarkdownSyntax(markdown: string): string {
-  return (
-    markdown
-      .replace(/\\\[\\\[/g, '[[')
-      .replace(/\\\*\\\*(\[\[[^\]\n]+\]\])\\\*\\\*/g, '**$1**')
-      .replace(/\\\*\\\*(\[[^\]\n]+\]\([^)]+\))\\\*\\\*/g, '**$1**')
-      .replace(/\\\*(\[\[[^\]\n]+\]\])\\\*/g, '*$1*')
-      .replace(/\\\*(\[[^\]\n]+\]\([^)]+\))\\\*/g, '*$1*')
-      .replace(/^> \\\[!(TIP|NOTE|WARNING|CAUTION|IMPORTANT)\]/gm, '> [!$1]')
-      // 이미지 캡션(alt)에 보존한 강조/취소선/인라인 코드/math 마커의 이스케이프를 해제합니다.
-      // alt 안의 이스케이프된 `\]`도 그대로 통과시키도록 escaped 문자를 허용합니다.
-      .replace(
-        /!\[((?:\\.|[^\]\\])*)\]\(/g,
-        (_full, alt: string) => `![${alt.replace(/\\([*_~`$])/g, '$1')}](`,
-      )
-  );
+  const restored = markdown
+    .replace(/\\\[\\\[/g, '[[')
+    .replace(/\\\*\\\*(\[\[[^\]\n]+\]\])\\\*\\\*/g, '**$1**')
+    .replace(/\\\*\\\*(\[[^\]\n]+\]\([^)]+\))\\\*\\\*/g, '**$1**')
+    .replace(/\\\*(\[\[[^\]\n]+\]\])\\\*/g, '*$1*')
+    .replace(/\\\*(\[[^\]\n]+\]\([^)]+\))\\\*/g, '*$1*')
+    .replace(/^> \\\[!(TIP|NOTE|WARNING|CAUTION|IMPORTANT)\]/gm, '> [!$1]');
+
+  // 이미지 캡션(alt)에 보존한 강조/취소선/인라인 코드/math 마커의 이스케이프를 해제합니다.
+  // 중첩 대괄호(`![a [b] c](...)`)를 고려해 alt 경계를 상태 머신으로 찾습니다.
+  return unescapeMarkersInImageAlts(restored);
 }
 
 function isReferencesHeading(node: RootContent): node is Heading {
@@ -455,10 +452,10 @@ export function transformMarkdownForExport(
     const endOffset = image.position?.end?.offset;
     if (typeof startOffset === 'number' && typeof endOffset === 'number') {
       const rawImage = normalizedContent.slice(startOffset, endOffset);
-      // 이스케이프된 `\]`가 alt에 있어도 잘리지 않도록 escaped 문자를 허용합니다.
-      const rawAltMatch = rawImage.match(/^!\[((?:\\.|[^\]\\])*)\]\(/);
-      if (rawAltMatch) {
-        image.alt = rawAltMatch[1];
+      // 중첩 대괄호(`![a [b] c](...)`)·이스케이프까지 고려해 alt를 정확히 추출합니다.
+      const rawAlt = extractImageAltAtStart(rawImage);
+      if (rawAlt !== null) {
+        image.alt = rawAlt;
       }
     }
 

--- a/src/libs/content/frontmatter.ts
+++ b/src/libs/content/frontmatter.ts
@@ -63,6 +63,25 @@ function normalizeCategoryColor(value: unknown): ContentFrontmatter['category_co
 }
 
 /**
+ * reading_time을 양의 정수(분)로 정규화합니다.
+ * 숫자, 숫자 문자열("5", "5 min") 모두 허용하고, 0 이하/비정상 값은 undefined입니다.
+ */
+function normalizeReadingTime(value: unknown): number | undefined {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+
+  return Math.round(parsed);
+}
+
+/**
  * frontmatter lang 값을 kr/en/ja로 정규화합니다.
  * lang이 없으면 kr(원문)이고, 알 수 없는 값이면 undefined를 반환합니다.
  * KB 원본이 일본어를 jp로 표기하는 전환기를 위해 jp는 ja로 매핑합니다.
@@ -108,6 +127,7 @@ export function normalizeFrontmatter(data: Record<string, unknown>): ContentFron
     as_of: normalizeDate(data.as_of),
     source_url: typeof data.source_url === 'string' ? data.source_url : undefined,
     archived_url: typeof data.archived_url === 'string' ? data.archived_url : undefined,
+    reading_time: normalizeReadingTime(data.reading_time),
   };
 }
 

--- a/src/libs/content/frontmatter.ts
+++ b/src/libs/content/frontmatter.ts
@@ -78,7 +78,9 @@ function normalizeReadingTime(value: unknown): number | undefined {
     return undefined;
   }
 
-  return Math.round(parsed);
+  // 반올림 후에도 양의 정수를 보장합니다(예: 0.4 → 0은 유효한 읽기 시간이 아님).
+  const minutes = Math.round(parsed);
+  return minutes > 0 ? minutes : undefined;
 }
 
 /**

--- a/src/libs/content/frontmatter.ts
+++ b/src/libs/content/frontmatter.ts
@@ -71,7 +71,7 @@ function normalizeReadingTime(value: unknown): number | undefined {
     typeof value === 'number'
       ? value
       : typeof value === 'string'
-        ? Number.parseInt(value, 10)
+        ? Number.parseFloat(value)
         : Number.NaN;
 
   if (!Number.isFinite(parsed) || parsed <= 0) {

--- a/src/libs/content/imageAlt.ts
+++ b/src/libs/content/imageAlt.ts
@@ -1,0 +1,65 @@
+/**
+ * 이미지 alt(캡션) 파싱 유틸.
+ *
+ * CommonMark의 이미지 설명(link label)에는 균형 잡힌 중첩 대괄호가 올 수 있어
+ * (`![a [b] c](url)`), 정규식 `!\[...\]\(` 으로는 alt 경계를 정확히 잘라낼 수 없습니다.
+ * 그래서 대괄호 depth와 이스케이프를 추적하는 상태 머신으로 파싱합니다.
+ */
+
+/**
+ * `![` 로 시작하는 문자열에서 이미지 alt를 추출합니다. 닫는 `]` 바로 뒤가 `(` 인,
+ * depth 0의 위치를 alt의 끝으로 봅니다. 유효한 `![alt](` 형태가 아니면 null.
+ */
+export function extractImageAltAtStart(raw: string): string | null {
+  if (!raw.startsWith('![')) {
+    return null;
+  }
+
+  let depth = 0;
+  for (let index = 2; index < raw.length; index += 1) {
+    const char = raw[index];
+
+    if (char === '\\') {
+      index += 1; // 이스케이프된 다음 문자는 특수문자로 취급하지 않습니다.
+      continue;
+    }
+
+    if (char === '[') {
+      depth += 1;
+    } else if (char === ']') {
+      if (depth === 0) {
+        return raw[index + 1] === '(' ? raw.slice(2, index) : null;
+      }
+      depth -= 1;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 마크다운 본문의 모든 `![alt](...)` 이미지에서, alt에 보존된 강조/취소선/인라인 코드/
+ * math 마커의 이스케이프(`\*` `\_` `\~` `` \` `` `\$`)를 해제합니다. 중첩 대괄호를
+ * 고려해 각 이미지 alt 경계를 상태 머신으로 찾습니다.
+ */
+export function unescapeMarkersInImageAlts(markdown: string): string {
+  let result = '';
+  let index = 0;
+
+  while (index < markdown.length) {
+    if (markdown[index] === '!' && markdown[index + 1] === '[') {
+      const alt = extractImageAltAtStart(markdown.slice(index));
+      if (alt !== null) {
+        const unescaped = alt.replace(/\\([*_~`$])/g, '$1');
+        result += `![${unescaped}](`;
+        index += 2 + alt.length + 2; // `![` + alt + `](`
+        continue;
+      }
+    }
+
+    result += markdown[index];
+    index += 1;
+  }
+
+  return result;
+}

--- a/src/libs/content/postMeta.ts
+++ b/src/libs/content/postMeta.ts
@@ -223,6 +223,7 @@ export function createPostMetaList(
       lastEditedAt: formatContentDate(updated),
       publishedAt,
       updatedAt,
+      readingTime: note.frontmatter.reading_time,
       category: {
         text: categoryText,
         color: resolveCategoryColor(categoryText, note.frontmatter.category_color),

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -2,7 +2,7 @@ import GithubSlugger from 'github-slugger';
 import type { Element, Root as HastRoot, Text as HastText } from 'hast';
 import { toString as hastToString } from 'hast-util-to-string';
 import { ExternalLink } from 'lucide-react';
-import type { Heading, Root as MdastRoot } from 'mdast';
+import type { Heading, PhrasingContent, Root as MdastRoot } from 'mdast';
 import { toString as mdastToString } from 'mdast-util-to-string';
 import Link from 'next/link';
 import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
@@ -22,6 +22,7 @@ import { unified } from 'unified';
 import type { Node } from 'unist';
 import { visit } from 'unist-util-visit';
 
+import { CodeBlock } from '@/components/ui/blog/CodeBlock';
 import { MarkdownImageLightbox } from '@/components/ui/blog/MarkdownImageLightbox';
 import { Mermaid } from '@/components/ui/blog/Mermaid';
 import { DEFAULT_POST_LANG } from '@/types/blog';
@@ -503,6 +504,54 @@ function remarkImageDimensions() {
   };
 }
 
+interface MdastPositionedNode {
+  position?: {
+    start?: { offset?: number };
+    end?: { offset?: number };
+  };
+  data?: {
+    hProperties?: Record<string, unknown>;
+  };
+}
+
+/**
+ * 이미지 캡션에 서식을 살리기 위한 플러그인.
+ *
+ * CommonMark는 `![*italic*](url)`의 alt를 계산할 때 강조 마커를 제거하므로,
+ * mdast `image.alt`만으로는 `*italic*`/`_italic_`/`~~del~~` 등을 복원할 수 없습니다.
+ * 그래서 원본 소스에서 alt 부분(`![` ~ `]`)을 그대로 잘라 `data-raw-alt`로 보존하고,
+ * 렌더 시 인라인 Markdown으로 다시 파싱합니다.
+ */
+function remarkImageRawCaption() {
+  return function transformer(tree: Node, file: { value?: unknown }) {
+    const source = typeof file.value === 'string' ? file.value : String(file.value ?? '');
+
+    visit(tree, 'image', node => {
+      const image = node as unknown as MdastPositionedNode;
+      const startOffset = image.position?.start?.offset;
+      const endOffset = image.position?.end?.offset;
+
+      if (typeof startOffset !== 'number' || typeof endOffset !== 'number') {
+        return;
+      }
+
+      const raw = source.slice(startOffset, endOffset);
+      const match = raw.match(/^!\[([\s\S]*?)\]\(/);
+      if (!match) {
+        return;
+      }
+
+      image.data = {
+        ...image.data,
+        hProperties: {
+          ...image.data?.hProperties,
+          'data-raw-alt': match[1],
+        },
+      };
+    });
+  };
+}
+
 function parseDetailsOpening(value: string): { summary: string; open: boolean } | null {
   const trimmed = value.trim();
 
@@ -649,6 +698,58 @@ function rehypeMermaidComponent() {
         };
       },
     );
+  };
+}
+
+function readStringProperty(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+/**
+ * rehype-pretty-code가 만든 `figure[data-rehype-pretty-code-figure]`를 커스텀
+ * `code-block` 엘리먼트로 치환합니다. 언어(`language`)와 줄 수(`lineCount`)를 넘겨
+ * 클라이언트 `CodeBlock`이 언어 라벨 · 복사 · 접기 chrome을 렌더링하게 합니다.
+ * rehypePrettyCode 이후에 실행되어야 합니다. (mermaid는 그 전에 이미 치환됨)
+ */
+function rehypeCodeBlock() {
+  return function transformer(tree: HastRoot) {
+    visit(tree, 'element', node => {
+      const element = node as Element;
+      if (element.tagName !== 'figure') {
+        return;
+      }
+
+      if (!element.properties || !('data-rehype-pretty-code-figure' in element.properties)) {
+        return;
+      }
+
+      const pre = element.children.find(
+        (child): child is Element => child.type === 'element' && child.tagName === 'pre',
+      );
+      if (!pre) {
+        return;
+      }
+
+      const code = pre.children.find(
+        (child): child is Element => child.type === 'element' && child.tagName === 'code',
+      );
+
+      const language =
+        readStringProperty(pre.properties?.['data-language']) ??
+        readStringProperty(code?.properties?.['data-language']);
+
+      const lineCount = code
+        ? code.children.filter(
+            child => child.type === 'element' && (child as Element).tagName === 'span',
+          ).length
+        : 0;
+
+      element.tagName = 'code-block';
+      element.properties = {
+        ...(language ? { language } : {}),
+        lineCount,
+      };
+    });
   };
 }
 
@@ -828,12 +929,53 @@ function MarkdownLink({ href = '', children, ...props }: ComponentPropsWithoutRe
   );
 }
 
-function MarkdownImage({ src, alt = '', title, width, height }: ComponentPropsWithoutRef<'img'>) {
+/**
+ * 인라인 Markdown(강조/굵게/취소선/인라인 코드)을 React 노드로 변환합니다.
+ * 이미지 캡션처럼 원래 순수 문자열로 렌더링되던 텍스트에 `*italic*`, `**bold**`
+ * 등의 서식을 적용하기 위해 사용합니다. 링크/이미지는 상위에서 텍스트로 평탄화됩니다.
+ */
+function renderInlineMarkdownNodes(nodes: PhrasingContent[]): ReactNode[] {
+  return nodes.map((node, index) => {
+    switch (node.type) {
+      case 'text':
+        return <Fragment key={index}>{node.value}</Fragment>;
+      case 'inlineCode':
+        return <code key={index}>{node.value}</code>;
+      case 'break':
+        return <br key={index} />;
+      case 'emphasis':
+        return <em key={index}>{renderInlineMarkdownNodes(node.children)}</em>;
+      case 'strong':
+        return <strong key={index}>{renderInlineMarkdownNodes(node.children)}</strong>;
+      case 'delete':
+        return <del key={index}>{renderInlineMarkdownNodes(node.children)}</del>;
+      default:
+        return <Fragment key={index}>{mdastToString(node)}</Fragment>;
+    }
+  });
+}
+
+function renderInlineMarkdownToReact(markdown: string): ReactNode {
+  return renderInlineMarkdownNodes(parseInlineMarkdownChildren(markdown));
+}
+
+function MarkdownImage({
+  src,
+  alt = '',
+  title,
+  width,
+  height,
+  ...props
+}: ComponentPropsWithoutRef<'img'>) {
   if (typeof src !== 'string') {
     return null;
   }
 
   const parsedAlt = parseMarkdownImageAlt(alt);
+  const rawAltAttr = (props as Record<string, unknown>)['data-raw-alt'];
+  // 원본 alt(강조 마커 보존)에서 크기 힌트(`|WxH`)만 벗겨낸 캡션 소스.
+  const rawCaption =
+    typeof rawAltAttr === 'string' ? parseMarkdownImageAlt(rawAltAttr).alt : parsedAlt.alt;
   const titleDimensions = parseMarkdownImageSizeSpec(title);
   const propDimensions = {
     width: parseMarkdownImageDimensionValue(width),
@@ -865,7 +1007,7 @@ function MarkdownImage({ src, alt = '', title, width, height }: ComponentPropsWi
     hasCustomDimensions ? 'max-w-full' : 'h-auto w-full',
     'rounded-lg border border-[color:var(--color-border)] object-contain',
   ].join(' ');
-  const caption = titleDimensions ? parsedAlt.alt : title || parsedAlt.alt;
+  const caption = titleDimensions ? rawCaption : title || rawCaption;
 
   return (
     <MarkdownImageLightbox
@@ -875,7 +1017,7 @@ function MarkdownImage({ src, alt = '', title, width, height }: ComponentPropsWi
       height={intrinsicHeight}
       className={imageClassName}
       style={imageStyle}
-      caption={caption || undefined}
+      caption={caption ? renderInlineMarkdownToReact(caption) : undefined}
       sized={hasCustomDimensions}
     />
   );
@@ -952,6 +1094,7 @@ export async function renderMarkdownToReact(
     .use(remarkMath)
     .use(remarkNormalizeKatexMath)
     .use(remarkImageDimensions)
+    .use(remarkImageRawCaption)
     .use(remarkWikiLink, {
       aliasDivider: '|',
       pageResolver: (pageName: string) => [pageName],
@@ -980,6 +1123,7 @@ export async function renderMarkdownToReact(
       },
       keepBackground: false,
     })
+    .use(rehypeCodeBlock)
     .use(rehypeReact, {
       Fragment,
       jsx,
@@ -988,6 +1132,9 @@ export async function renderMarkdownToReact(
         a: MarkdownLink,
         img: MarkdownImage,
         mermaid: Mermaid,
+        'code-block': (props: ComponentPropsWithoutRef<typeof CodeBlock>) => (
+          <CodeBlock {...props} lang={lang} />
+        ),
         'reference-card': ReferenceCard,
       },
     })

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -536,7 +536,8 @@ function remarkImageRawCaption() {
       }
 
       const raw = source.slice(startOffset, endOffset);
-      const match = raw.match(/^!\[([\s\S]*?)\]\(/);
+      // 캡션에 이스케이프된 `\]`가 있어도 잘리지 않도록 escaped 문자를 허용합니다.
+      const match = raw.match(/^!\[((?:\\.|[^\]\\])*)\]\(/);
       if (!match) {
         return;
       }

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -1009,6 +1009,8 @@ function MarkdownImage({
     'rounded-lg border border-[color:var(--color-border)] object-contain',
   ].join(' ');
   const caption = titleDimensions ? rawCaption : title || rawCaption;
+  // 접근성 라벨 폴백용 순수 텍스트(강조 마커 없는 평탄화 버전).
+  const captionText = titleDimensions ? parsedAlt.alt : title || parsedAlt.alt;
 
   return (
     <MarkdownImageLightbox
@@ -1019,6 +1021,7 @@ function MarkdownImage({
       className={imageClassName}
       style={imageStyle}
       caption={caption ? renderInlineMarkdownToReact(caption) : undefined}
+      captionText={captionText || undefined}
       sized={hasCustomDimensions}
     />
   );

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -28,6 +28,7 @@ import { Mermaid } from '@/components/ui/blog/Mermaid';
 import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang, TableOfContentsItem } from '@/types/blog';
 
+import { extractImageAltAtStart } from './imageAlt';
 import {
   DEFAULT_MARKDOWN_IMAGE_HEIGHT,
   DEFAULT_MARKDOWN_IMAGE_WIDTH,
@@ -536,9 +537,9 @@ function remarkImageRawCaption() {
       }
 
       const raw = source.slice(startOffset, endOffset);
-      // 캡션에 이스케이프된 `\]`가 있어도 잘리지 않도록 escaped 문자를 허용합니다.
-      const match = raw.match(/^!\[((?:\\.|[^\]\\])*)\]\(/);
-      if (!match) {
+      // 중첩 대괄호(`![a [b] c](...)`)·이스케이프까지 고려해 alt를 정확히 추출합니다.
+      const rawAlt = extractImageAltAtStart(raw);
+      if (rawAlt === null) {
         return;
       }
 
@@ -546,7 +547,7 @@ function remarkImageRawCaption() {
         ...image.data,
         hProperties: {
           ...image.data?.hProperties,
-          'data-raw-alt': match[1],
+          'data-raw-alt': rawAlt,
         },
       };
     });

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -1136,7 +1136,9 @@ export async function renderMarkdownToReact(
       components: {
         a: MarkdownLink,
         img: MarkdownImage,
-        mermaid: Mermaid,
+        mermaid: (props: ComponentPropsWithoutRef<typeof Mermaid>) => (
+          <Mermaid {...props} lang={lang} />
+        ),
         'code-block': (props: ComponentPropsWithoutRef<typeof CodeBlock>) => (
           <CodeBlock {...props} lang={lang} />
         ),

--- a/src/libs/content/types.ts
+++ b/src/libs/content/types.ts
@@ -32,6 +32,10 @@ export interface ContentFrontmatter {
   as_of?: string;
   source_url?: string;
   archived_url?: string;
+  /**
+   * 예상 읽기 시간(분). KB frontmatter에서 주입됩니다.
+   */
+  reading_time?: number;
   [key: string]: unknown;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -83,6 +83,31 @@
   --color-surface: #f5f5f3;
   --color-border: rgba(0, 0, 0, 0.1);
 
+  /* PostBody 본문 색 토큰 (src/styles/markdown.css의 .post-body에서 사용) */
+  --pb-text: var(--color-text);
+  --pb-muted: var(--color-text-secondary);
+  --pb-faint: rgba(0, 0, 0, 0.4);
+  --pb-border: var(--color-border);
+  --pb-border-strong: rgba(0, 0, 0, 0.16);
+  --pb-fill-subtle: rgba(0, 0, 0, 0.03);
+  --pb-surface: var(--color-surface);
+  --pb-surface-2: #ececea;
+  --pb-accent: #2563eb;
+  --pb-accent-soft: rgba(37, 99, 235, 0.12);
+  --pb-inline-code: #e5484d;
+  --pb-success: #16a34a;
+  --pb-selection: rgba(37, 99, 235, 0.24);
+  --pb-alert-note: #2563eb;
+  --pb-alert-tip: #16a34a;
+  --pb-alert-important: #7c3aed;
+  --pb-alert-warning: #d97706;
+  --pb-alert-caution: #dc2626;
+  --pb-alert-note-bg: rgba(37, 99, 235, 0.08);
+  --pb-alert-tip-bg: rgba(22, 163, 74, 0.1);
+  --pb-alert-important-bg: rgba(124, 58, 237, 0.08);
+  --pb-alert-warning-bg: rgba(217, 119, 6, 0.1);
+  --pb-alert-caution-bg: rgba(220, 38, 38, 0.08);
+
   /* 클릭된 상태용 색상 (다크 모드 색상 사용) */
   --color-primary-clicked: #5a5a58;
   --color-secondary-clicked: #4d4f4f;
@@ -121,6 +146,28 @@
   --color-text-secondary: rgba(255, 255, 255, 0.56);
   --color-surface: rgba(255, 255, 255, 0.05);
   --color-border: rgba(255, 255, 255, 0.12);
+
+  /* PostBody 본문 색 토큰 (다크) — --pb-text/muted/border/surface는 위 --color-*를
+     참조하므로 여기서 재정의하지 않습니다. */
+  --pb-faint: rgba(255, 255, 255, 0.42);
+  --pb-border-strong: rgba(255, 255, 255, 0.2);
+  --pb-fill-subtle: rgba(255, 255, 255, 0.05);
+  --pb-surface-2: rgba(255, 255, 255, 0.09);
+  --pb-accent: #6ea8fe;
+  --pb-accent-soft: rgba(110, 168, 254, 0.16);
+  --pb-inline-code: #ff8785;
+  --pb-success: #4ade80;
+  --pb-selection: rgba(110, 168, 254, 0.3);
+  --pb-alert-note: #6ea8fe;
+  --pb-alert-tip: #4ade80;
+  --pb-alert-important: #b794f6;
+  --pb-alert-warning: #fbbf24;
+  --pb-alert-caution: #fb7185;
+  --pb-alert-note-bg: rgba(110, 168, 254, 0.14);
+  --pb-alert-tip-bg: rgba(74, 222, 128, 0.14);
+  --pb-alert-important-bg: rgba(183, 148, 246, 0.14);
+  --pb-alert-warning-bg: rgba(251, 191, 36, 0.14);
+  --pb-alert-caution-bg: rgba(251, 113, 133, 0.14);
 
   /* 클릭된 상태용 색상 (라이트 모드 색상 사용) */
   --color-primary-clicked: #e8e8e6;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -107,6 +107,8 @@
   --pb-alert-important-bg: rgba(124, 58, 237, 0.08);
   --pb-alert-warning-bg: rgba(217, 119, 6, 0.1);
   --pb-alert-caution-bg: rgba(220, 38, 38, 0.08);
+  /* mermaid 카드 배경 — 기본(밝은) 팔레트가 잘 보이도록 라이트/다크 공통 밝은 표면 */
+  --pb-mermaid-surface: #f8fafc;
 
   /* 클릭된 상태용 색상 (다크 모드 색상 사용) */
   --color-primary-clicked: #5a5a58;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -78,6 +78,10 @@
   --color-primary: #e2e2e1;
   --color-secondary: #e6e7e7;
   --color-background-secondary: var(--color-neutral-100);
+  /* 시맨틱 보조 토큰 (본문/카드 공통) */
+  --color-text-secondary: rgba(0, 0, 0, 0.56);
+  --color-surface: #f5f5f3;
+  --color-border: rgba(0, 0, 0, 0.1);
 
   /* 클릭된 상태용 색상 (다크 모드 색상 사용) */
   --color-primary-clicked: #5a5a58;
@@ -113,6 +117,10 @@
   --color-primary: #5a5a58;
   --color-secondary: #4d4f4f;
   --color-background-secondary: var(--color-neutral-950);
+  /* 시맨틱 보조 토큰 (본문/카드 공통) */
+  --color-text-secondary: rgba(255, 255, 255, 0.56);
+  --color-surface: rgba(255, 255, 255, 0.05);
+  --color-border: rgba(255, 255, 255, 0.12);
 
   /* 클릭된 상태용 색상 (라이트 모드 색상 사용) */
   --color-primary-clicked: #e8e8e6;

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -359,6 +359,124 @@
   tab-size: 2;
 }
 
+/* 코드 블록 chrome: 언어 라벨 + 복사 버튼 + 긴 블록 접기 */
+.post-body .code-block {
+  width: 100%;
+  margin: 0.75rem 0;
+  overflow: hidden;
+  border: 0.0625rem solid var(--fg-color-0);
+  border-radius: 0.375rem;
+  background: var(--bg-color-1);
+}
+
+.post-body .code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem 0.375rem 0.75rem;
+  border-bottom: 0.0625rem solid var(--fg-color-0);
+}
+
+.post-body .code-block-language {
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--fg-color-3);
+  text-transform: uppercase;
+}
+
+.post-body .code-block-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border: 0;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--fg-color-3);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.post-body .code-block-copy:hover {
+  background: var(--bg-color-2);
+  color: var(--fg-color-6);
+}
+
+.post-body .code-block-copy[data-copied='true'] {
+  color: var(--notion-teal);
+}
+
+.post-body .code-block-copy svg {
+  width: 0.9375rem;
+  height: 0.9375rem;
+}
+
+.post-body .code-block-content {
+  position: relative;
+}
+
+.post-body .code-block-content[data-collapsed='true'] {
+  max-height: 22rem;
+  overflow: hidden;
+}
+
+.post-body .code-block-content[data-collapsed='true']::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 4rem;
+  background: linear-gradient(to bottom, transparent, var(--bg-color-1));
+  pointer-events: none;
+}
+
+/* 코드 블록 안의 pre는 chrome에 맞춰 독립 스타일을 제거 */
+.post-body .code-block-content pre {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.post-body .code-block-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.4375rem;
+  border: 0;
+  border-top: 0.0625rem solid var(--fg-color-0);
+  background: transparent;
+  color: var(--fg-color-3);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.post-body .code-block-toggle:hover {
+  background: var(--bg-color-2);
+  color: var(--fg-color-6);
+}
+
+.post-body .code-block-toggle-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+  transition: transform 0.2s ease;
+}
+
+.post-body .code-block-toggle-icon[data-expanded='true'] {
+  transform: rotate(180deg);
+}
+
 .post-body pre code {
   display: block;
   min-width: max-content;

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -53,13 +53,44 @@
   --markdown-alert-caution-bg: rgba(253, 71, 58, 0.14);
 }
 
+/*
+ * PostBody 모던 디자인 토큰.
+ * Notion 유래 --fg-color/--bg-color 스케일 대신, 사이트 팔레트(#fafaf8 / #0f0f0e)에
+ * 정렬된 표면/보더/뮤트/액센트 값을 PostBody에만 스코프해서 사용합니다.
+ */
+.post-body {
+  --pb-text: var(--color-text);
+  --pb-muted: rgba(0, 0, 0, 0.56);
+  --pb-faint: rgba(0, 0, 0, 0.4);
+  --pb-surface: #f5f5f3;
+  --pb-surface-2: #ececea;
+  --pb-border: rgba(0, 0, 0, 0.1);
+  --pb-border-strong: rgba(0, 0, 0, 0.16);
+  --pb-accent: #2563eb;
+  --pb-accent-soft: rgba(37, 99, 235, 0.12);
+  --pb-inline-code: #e5484d;
+}
+
+[data-theme='dark'] .post-body,
+.dark-mode .post-body {
+  --pb-muted: rgba(255, 255, 255, 0.56);
+  --pb-faint: rgba(255, 255, 255, 0.42);
+  --pb-surface: rgba(255, 255, 255, 0.05);
+  --pb-surface-2: rgba(255, 255, 255, 0.09);
+  --pb-border: rgba(255, 255, 255, 0.12);
+  --pb-border-strong: rgba(255, 255, 255, 0.2);
+  --pb-accent: #6ea8fe;
+  --pb-accent-soft: rgba(110, 168, 254, 0.16);
+  --pb-inline-code: #ff8785;
+}
+
 .post-body {
   width: 100%;
-  color: var(--fg-color);
-  caret-color: var(--fg-color);
+  color: var(--pb-text);
+  caret-color: var(--pb-text);
   font-family: var(--font-pretendard), var(--notion-font), sans-serif;
-  font-size: 1rem;
-  line-height: 1.6;
+  font-size: 1.0625rem;
+  line-height: 1.75;
   word-break: break-word;
   overflow-wrap: break-word;
 }
@@ -75,7 +106,7 @@
 }
 
 .post-body > * {
-  padding: 0.1875rem 0.125rem;
+  padding: 0;
 }
 
 .post-body > *:first-child {
@@ -94,23 +125,24 @@
 .post-body h6 {
   position: relative;
   display: block;
-  width: fit-content;
+  width: 100%;
   max-width: 100%;
-  margin: 0 0 0.5rem;
-  padding: 0.1875rem 0.125rem;
-  color: var(--fg-color);
+  margin: 0 0 0.6rem;
+  padding: 0;
+  color: var(--pb-text);
   font-family: inherit;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1.3;
+  letter-spacing: -0.011em;
   white-space: pre-wrap;
   word-break: break-word;
   scroll-margin-top: 7rem;
 }
 
 .post-body h1 {
-  margin-top: 1.4rem;
-  font-size: 1.875rem;
-  font-weight: 700;
+  margin-top: 2.75rem;
+  font-size: 2.125rem;
+  letter-spacing: -0.02em;
 }
 
 .post-body h1:first-child {
@@ -118,20 +150,29 @@
 }
 
 .post-body h2 {
-  margin-top: 1rem;
-  font-size: 1.5rem;
+  margin-top: 2.5rem;
+  font-size: 1.6rem;
+  letter-spacing: -0.017em;
 }
 
 .post-body h3 {
-  margin-top: 0.9rem;
-  font-size: 1.25rem;
+  margin-top: 1.85rem;
+  font-size: 1.3rem;
 }
 
-.post-body h4,
+.post-body h4 {
+  margin-top: 1.5rem;
+  font-size: 1.1rem;
+}
+
 .post-body h5,
 .post-body h6 {
-  margin-top: 0.8rem;
+  margin-top: 1.25rem;
   font-size: 1rem;
+}
+
+.post-body h6 {
+  color: var(--pb-muted);
 }
 
 .post-body .heading-anchor {
@@ -143,31 +184,31 @@
 
 .post-body p {
   width: 100%;
-  margin: 0.0625rem 0;
-  padding: 0.1875rem 0.125rem;
-  font-size: 1rem;
-  line-height: 1.6;
+  margin: 1.15rem 0;
+  padding: 0;
+  line-height: 1.75;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 .post-body a {
-  color: inherit;
+  color: var(--pb-accent);
   word-break: break-word;
-  text-decoration: inherit;
-  border-bottom: 0.05rem solid var(--fg-color-2);
-  opacity: 0.7;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--pb-accent) 40%, transparent);
+  text-decoration-thickness: 0.0625rem;
+  text-underline-offset: 0.2em;
   transition:
-    border-color 100ms ease-in,
-    opacity 100ms ease-in;
+    text-decoration-color 150ms ease,
+    color 150ms ease;
 }
 
 .post-body a:hover {
-  border-color: var(--fg-color-6);
-  opacity: 1;
+  text-decoration-color: var(--pb-accent);
 }
 
 .post-body strong {
+  color: var(--pb-text);
   font-weight: 700;
 }
 
@@ -176,25 +217,27 @@
 }
 
 .post-body del {
-  opacity: 0.72;
+  color: var(--pb-muted);
 }
 
 .post-body hr {
   width: 100%;
-  margin: 0.375rem 0;
+  margin: 2.5rem 0;
   padding: 0;
   border: 0;
-  border-top: 0.0625rem solid var(--fg-color);
+  border-top: 0.0625rem solid var(--pb-border);
 }
 
 .post-body blockquote {
   display: block;
   width: 100%;
-  margin: 0.25rem 0;
-  padding: 0.15rem 0.9rem;
-  border-left: 0.1875rem solid currentcolor;
-  font-size: 1rem;
-  line-height: 1.6;
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.15rem;
+  border-left: 0.1875rem solid var(--pb-border-strong);
+  border-radius: 0 0.375rem 0.375rem 0;
+  background: var(--pb-surface);
+  color: var(--pb-muted);
+  line-height: 1.7;
   word-break: break-word;
 }
 
@@ -204,44 +247,44 @@
 }
 
 .post-body blockquote > p + p {
-  margin-top: 0.5rem;
+  margin-top: 0.65rem;
 }
 
-.post-body blockquote em {
-  font-style: normal;
+.post-body blockquote strong {
+  color: var(--pb-text);
 }
 
 .post-body .markdown-details {
   display: block;
   width: 100%;
-  margin: 0.6rem 0;
-  padding: 0.35rem 0.55rem;
-  border: 0.0625rem solid var(--fg-color-0);
-  border-radius: 0.5rem;
-  background: var(--bg-color-1);
+  margin: 1.35rem 0;
+  padding: 0.5rem 0.9rem;
+  border: 0.0625rem solid var(--pb-border);
+  border-radius: 0.625rem;
+  background: var(--pb-surface);
 }
 
 .post-body .markdown-details-summary {
   display: list-item;
   padding: 0.35rem 0.2rem;
-  color: var(--fg-color);
+  color: var(--pb-text);
   font-weight: 600;
   line-height: 1.5;
   cursor: pointer;
 }
 
 .post-body .markdown-details-summary::marker {
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
 }
 
 .post-body .markdown-details-summary:hover {
-  color: var(--fg-color-6);
+  color: var(--pb-accent);
 }
 
 .post-body .markdown-details-content {
   margin-top: 0.3rem;
   padding-top: 0.45rem;
-  border-top: 0.0625rem solid var(--fg-color-0);
+  border-top: 0.0625rem solid var(--pb-border);
 }
 
 .post-body .markdown-details-content > *:first-child {
@@ -255,27 +298,38 @@
 .post-body ul,
 .post-body ol {
   width: 100%;
-  margin: 0.6rem 0;
+  margin: 1.15rem 0;
 }
 
 .post-body ul {
-  padding-inline-start: 1.7rem;
+  padding-inline-start: 1.5rem;
   list-style-type: disc;
 }
 
 .post-body ol {
-  padding-inline-start: 1.6rem;
+  padding-inline-start: 1.5rem;
   list-style-type: decimal;
 }
 
 .post-body li {
-  padding: 0.375rem 0;
+  padding: 0.2rem 0;
+  line-height: 1.75;
   white-space: pre-wrap;
+}
+
+.post-body li::marker {
+  color: var(--pb-faint);
 }
 
 .post-body li > p {
   margin: 0;
   padding: 0;
+}
+
+/* 중첩 리스트는 상위 항목과 촘촘하게 붙입니다. */
+.post-body li > ul,
+.post-body li > ol {
+  margin: 0.2rem 0;
 }
 
 .post-body .contains-task-list {
@@ -289,28 +343,38 @@
   align-items: flex-start;
 }
 
+.post-body .task-list-item::marker {
+  content: '';
+}
+
 .post-body .task-list-item input[type='checkbox'] {
   flex: 0 0 auto;
   width: 1rem;
   height: 1rem;
-  margin-top: 0.25rem;
-  accent-color: var(--fg-color-6);
+  margin-top: 0.4rem;
+  accent-color: var(--pb-accent);
 }
 
 .post-body table {
   display: block;
-  width: 100%;
-  margin: 0.25rem 0;
+  width: fit-content;
+  max-width: 100%;
+  margin: 1rem 0;
   padding: 0;
   overflow-x: auto;
-  border-collapse: collapse;
-  font-size: 1rem;
+  border: 0.0625rem solid var(--pb-border);
+  border-radius: 0.5rem;
+  border-spacing: 0;
+  border-collapse: separate;
+  font-size: 0.9375rem;
+  line-height: 1.6;
 }
 
 .post-body th,
 .post-body td {
-  padding: 0.5rem;
-  border: 0.0625rem solid var(--fg-color-5);
+  padding: 0.55rem 0.9rem;
+  border-right: 0.0625rem solid var(--pb-border);
+  border-bottom: 0.0625rem solid var(--pb-border);
   text-align: left;
   vertical-align: top;
   white-space: normal;
@@ -318,22 +382,39 @@
   overflow-wrap: break-word;
 }
 
+.post-body th:last-child,
+.post-body td:last-child {
+  border-right: 0;
+}
+
+.post-body tbody tr:last-child td {
+  border-bottom: 0;
+}
+
 .post-body th {
-  background: var(--bg-color-0);
-  font-weight: 700;
+  border-bottom: 0.0625rem solid var(--pb-border-strong);
+  background: var(--pb-surface);
+  color: var(--pb-text);
+  font-weight: 600;
 }
 
 .post-body tbody tr:nth-child(even) {
-  background: transparent;
+  background: color-mix(in srgb, var(--pb-surface) 55%, transparent);
+}
+
+.post-body tbody tr:hover {
+  background: var(--pb-surface);
 }
 
 .post-body :not(pre) > code {
-  padding: 0.2rem 0.4rem;
-  border-radius: 0.1875rem;
-  background: var(--bg-color-2);
-  color: #eb5757;
+  padding: 0.1rem 0.34rem;
+  border: 0.0625rem solid var(--pb-border);
+  border-radius: 0.3125rem;
+  background: var(--pb-surface);
+  color: var(--pb-inline-code);
   font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-  font-size: 85%;
+  font-size: 0.85em;
+  word-break: break-word;
 }
 
 .post-body figure[data-rehype-pretty-code-figure] {
@@ -346,27 +427,27 @@
   position: relative;
   display: block;
   width: 100%;
-  margin: 0.25rem 0;
-  padding: 1rem;
+  margin: 1.15rem 0;
+  padding: 1rem 1.15rem;
   overflow: auto;
-  border: 0;
-  border-radius: 0.1875rem;
-  background: var(--bg-color-1);
-  color: var(--fg-color);
+  border: 0.0625rem solid var(--pb-border);
+  border-radius: 0.5rem;
+  background: var(--pb-surface);
+  color: var(--pb-text);
   font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 0.875rem;
-  line-height: 1.5;
+  line-height: 1.6;
   tab-size: 2;
 }
 
 /* 코드 블록 chrome: 언어 라벨 + 복사 버튼 + 긴 블록 접기 */
 .post-body .code-block {
   width: 100%;
-  margin: 0.75rem 0;
+  margin: 1.35rem 0;
   overflow: hidden;
-  border: 0.0625rem solid var(--fg-color-0);
-  border-radius: 0.375rem;
-  background: var(--bg-color-1);
+  border: 0.0625rem solid var(--pb-border);
+  border-radius: 0.625rem;
+  background: var(--pb-surface);
 }
 
 .post-body .code-block-header {
@@ -374,8 +455,8 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  padding: 0.375rem 0.5rem 0.375rem 0.75rem;
-  border-bottom: 0.0625rem solid var(--fg-color-0);
+  padding: 0.375rem 0.5rem 0.375rem 0.9rem;
+  border-bottom: 0.0625rem solid var(--pb-border);
 }
 
 .post-body .code-block-language {
@@ -383,7 +464,7 @@
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.02em;
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
   text-transform: uppercase;
 }
 
@@ -391,11 +472,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.25rem;
+  padding: 0.3rem;
   border: 0;
-  border-radius: 0.25rem;
+  border-radius: 0.375rem;
   background: transparent;
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
   cursor: pointer;
   transition:
     background 0.15s ease,
@@ -403,12 +484,19 @@
 }
 
 .post-body .code-block-copy:hover {
-  background: var(--bg-color-2);
-  color: var(--fg-color-6);
+  background: var(--pb-surface-2);
+  color: var(--pb-text);
 }
 
 .post-body .code-block-copy[data-copied='true'] {
-  color: var(--notion-teal);
+  color: #16a34a;
+}
+
+.post-body .code-block-copy:focus-visible,
+.post-body .code-block-toggle:focus-visible {
+  outline: 0.125rem solid var(--pb-accent);
+  outline-offset: -0.125rem;
+  color: var(--pb-text);
 }
 
 .post-body .code-block-copy svg {
@@ -432,7 +520,7 @@
   bottom: 0;
   left: 0;
   height: 4rem;
-  background: linear-gradient(to bottom, transparent, var(--bg-color-1));
+  background: linear-gradient(to bottom, transparent, var(--pb-surface));
   pointer-events: none;
 }
 
@@ -452,9 +540,9 @@
   gap: 0.25rem;
   padding: 0.4375rem;
   border: 0;
-  border-top: 0.0625rem solid var(--fg-color-0);
+  border-top: 0.0625rem solid var(--pb-border);
   background: transparent;
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
   font-size: 0.75rem;
   cursor: pointer;
   transition:
@@ -463,8 +551,8 @@
 }
 
 .post-body .code-block-toggle:hover {
-  background: var(--bg-color-2);
-  color: var(--fg-color-6);
+  background: var(--pb-surface-2);
+  color: var(--pb-text);
 }
 
 .post-body .code-block-toggle-icon {
@@ -563,7 +651,7 @@
 
 .post-body .markdown-image span {
   margin-top: 0.5rem;
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
   font-size: 0.875rem;
   text-align: center;
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -69,6 +69,7 @@
   --pb-accent: #2563eb;
   --pb-accent-soft: rgba(37, 99, 235, 0.12);
   --pb-inline-code: #e5484d;
+  --pb-success: #16a34a;
 }
 
 [data-theme='dark'] .post-body,
@@ -82,6 +83,7 @@
   --pb-accent: #6ea8fe;
   --pb-accent-soft: rgba(110, 168, 254, 0.16);
   --pb-inline-code: #ff8785;
+  --pb-success: #4ade80;
 }
 
 .post-body {
@@ -489,7 +491,7 @@
 }
 
 .post-body .code-block-copy[data-copied='true'] {
-  color: #16a34a;
+  color: var(--pb-success);
 }
 
 .post-body .code-block-copy:focus-visible,

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -809,7 +809,7 @@
 }
 
 .post-body .markdown-alert-note {
-  --pb-alert-border: rgba(11, 110, 153, 0.22);
+  --pb-alert-border: color-mix(in srgb, var(--pb-alert-note) 42%, transparent);
   --pb-alert-bg: var(--pb-alert-note-bg);
 }
 
@@ -818,7 +818,7 @@
 }
 
 .post-body .markdown-alert-tip {
-  --pb-alert-border: rgba(77, 100, 97, 0.22);
+  --pb-alert-border: color-mix(in srgb, var(--pb-alert-tip) 42%, transparent);
   --pb-alert-bg: var(--pb-alert-tip-bg);
 }
 
@@ -827,7 +827,7 @@
 }
 
 .post-body .markdown-alert-important {
-  --pb-alert-border: rgba(105, 64, 165, 0.22);
+  --pb-alert-border: color-mix(in srgb, var(--pb-alert-important) 42%, transparent);
   --pb-alert-bg: var(--pb-alert-important-bg);
 }
 
@@ -836,7 +836,7 @@
 }
 
 .post-body .markdown-alert-warning {
-  --pb-alert-border: rgba(223, 171, 1, 0.26);
+  --pb-alert-border: color-mix(in srgb, var(--pb-alert-warning) 46%, transparent);
   --pb-alert-bg: var(--pb-alert-warning-bg);
 }
 
@@ -845,7 +845,7 @@
 }
 
 .post-body .markdown-alert-caution {
-  --pb-alert-border: rgba(224, 62, 62, 0.22);
+  --pb-alert-border: color-mix(in srgb, var(--pb-alert-caution) 42%, transparent);
   --pb-alert-bg: var(--pb-alert-caution-bg);
 }
 
@@ -867,7 +867,7 @@
   margin: 1.5rem 0;
   padding: 1rem;
   border-radius: 0.625rem;
-  background: #f8fafc;
+  background: var(--pb-mermaid-surface);
   text-align: center;
 }
 

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,68 +1,11 @@
 /*
- * PostBody 모던 디자인 토큰.
- * Notion 유래(--fg-color/--bg-color/--notion-*) 스케일을 걷어내고, 사이트 팔레트
- * (#fafaf8 / #0f0f0e)에 정렬된 표면·보더·뮤트·액센트·알림 색을 PostBody에만 스코프해
- * 사용합니다. 인라인 코드만 의도적으로 빨간 계열(--pb-inline-code)을 유지합니다.
+ * PostBody 본문 폰트 토큰. 색 토큰(--pb-*)은 레포 가이드("색은 globals.css CSS
+ * 변수만 씁니다")에 따라 src/styles/globals.css에서 라이트/다크로 정의합니다.
  */
 .post-body {
   --pb-sans:
     var(--font-pretendard), ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
   --pb-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-
-  /* 글로벌 시맨틱 토큰을 참조해 중복/드리프트를 피합니다(라이트/다크는 globals에서 전환). */
-  --pb-text: var(--color-text);
-  --pb-muted: var(--color-text-secondary);
-  --pb-border: var(--color-border);
-  --pb-surface: var(--color-surface);
-  /* PostBody 전용 보조 스케일(글로벌에 대응 토큰이 없는 값) */
-  --pb-faint: rgba(0, 0, 0, 0.4);
-  --pb-border-strong: rgba(0, 0, 0, 0.16);
-  --pb-fill-subtle: rgba(0, 0, 0, 0.03);
-  --pb-surface-2: #ececea;
-
-  --pb-accent: #2563eb;
-  --pb-accent-soft: rgba(37, 99, 235, 0.12);
-  --pb-inline-code: #e5484d;
-  --pb-success: #16a34a;
-  --pb-selection: rgba(37, 99, 235, 0.24);
-
-  --pb-alert-note: #2563eb;
-  --pb-alert-tip: #16a34a;
-  --pb-alert-important: #7c3aed;
-  --pb-alert-warning: #d97706;
-  --pb-alert-caution: #dc2626;
-  --pb-alert-note-bg: rgba(37, 99, 235, 0.08);
-  --pb-alert-tip-bg: rgba(22, 163, 74, 0.1);
-  --pb-alert-important-bg: rgba(124, 58, 237, 0.08);
-  --pb-alert-warning-bg: rgba(217, 119, 6, 0.1);
-  --pb-alert-caution-bg: rgba(220, 38, 38, 0.08);
-}
-
-[data-theme='dark'] .post-body,
-.dark-mode .post-body {
-  /* --pb-muted/border/surface는 globals의 --color-* 를 참조하므로 여기서 재정의하지
-     않습니다(globals 다크에서 함께 전환). 아래는 PostBody 전용 보조 스케일만 전환. */
-  --pb-faint: rgba(255, 255, 255, 0.42);
-  --pb-border-strong: rgba(255, 255, 255, 0.2);
-  --pb-fill-subtle: rgba(255, 255, 255, 0.05);
-  --pb-surface-2: rgba(255, 255, 255, 0.09);
-
-  --pb-accent: #6ea8fe;
-  --pb-accent-soft: rgba(110, 168, 254, 0.16);
-  --pb-inline-code: #ff8785;
-  --pb-success: #4ade80;
-  --pb-selection: rgba(110, 168, 254, 0.3);
-
-  --pb-alert-note: #6ea8fe;
-  --pb-alert-tip: #4ade80;
-  --pb-alert-important: #b794f6;
-  --pb-alert-warning: #fbbf24;
-  --pb-alert-caution: #fb7185;
-  --pb-alert-note-bg: rgba(110, 168, 254, 0.14);
-  --pb-alert-tip-bg: rgba(74, 222, 128, 0.14);
-  --pb-alert-important-bg: rgba(183, 148, 246, 0.14);
-  --pb-alert-warning-bg: rgba(251, 191, 36, 0.14);
-  --pb-alert-caution-bg: rgba(251, 113, 133, 0.14);
 }
 
 .post-body {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,96 +1,74 @@
-:root {
-  --notion-font:
-    ui-sans-serif, system-ui, apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
-    'Apple Color Emoji', Arial, sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol';
-  --fg-color: rgb(55, 53, 47);
-  --fg-color-0: rgba(55, 53, 47, 0.09);
-  --fg-color-1: rgba(55, 53, 47, 0.16);
-  --fg-color-2: rgba(55, 53, 47, 0.4);
-  --fg-color-3: rgba(55, 53, 47, 0.6);
-  --fg-color-5: rgba(55, 53, 47, 0.024);
-  --fg-color-6: rgba(55, 53, 47, 0.8);
-  --fg-color-icon: var(--fg-color);
-  --bg-color: #fff;
-  --bg-color-0: rgba(135, 131, 120, 0.15);
-  --bg-color-1: rgb(247, 246, 243);
-  --bg-color-2: rgba(135, 131, 120, 0.15);
-  --select-color-1: rgba(45, 170, 219, 0.3);
-  --notion-red: rgb(224, 62, 62);
-  --notion-blue: rgb(11, 110, 153);
-  --notion-purple: rgb(105, 64, 165);
-  --notion-yellow: rgb(223, 171, 1);
-  --notion-teal: rgb(77, 100, 97);
-  --markdown-alert-note-bg: rgba(11, 110, 153, 0.08);
-  --markdown-alert-tip-bg: rgba(77, 100, 97, 0.1);
-  --markdown-alert-important-bg: rgba(105, 64, 165, 0.08);
-  --markdown-alert-warning-bg: rgba(223, 171, 1, 0.12);
-  --markdown-alert-caution-bg: rgba(224, 62, 62, 0.08);
-}
-
-[data-theme='dark'],
-.dark-mode {
-  --fg-color: rgba(255, 255, 255, 0.9);
-  --fg-color-0: rgba(255, 255, 255, 0.13);
-  --fg-color-1: rgba(255, 255, 255, 0.18);
-  --fg-color-2: rgba(255, 255, 255, 0.45);
-  --fg-color-3: rgba(255, 255, 255, 0.62);
-  --fg-color-5: rgba(255, 255, 255, 0.16);
-  --fg-color-6: #fff;
-  --fg-color-icon: #fff;
-  --bg-color: #2f3437;
-  --bg-color-0: rgb(71, 76, 80);
-  --bg-color-1: rgb(63, 68, 71);
-  --bg-color-2: rgba(135, 131, 120, 0.15);
-  --notion-red: rgb(253, 71, 58);
-  --notion-blue: rgb(82, 156, 202);
-  --notion-purple: rgb(154, 109, 215);
-  --notion-yellow: rgb(255, 220, 73);
-  --notion-teal: rgb(77, 171, 154);
-  --markdown-alert-note-bg: rgba(82, 156, 202, 0.14);
-  --markdown-alert-tip-bg: rgba(77, 171, 154, 0.14);
-  --markdown-alert-important-bg: rgba(154, 109, 215, 0.14);
-  --markdown-alert-warning-bg: rgba(255, 220, 73, 0.14);
-  --markdown-alert-caution-bg: rgba(253, 71, 58, 0.14);
-}
-
 /*
  * PostBody 모던 디자인 토큰.
- * Notion 유래 --fg-color/--bg-color 스케일 대신, 사이트 팔레트(#fafaf8 / #0f0f0e)에
- * 정렬된 표면/보더/뮤트/액센트 값을 PostBody에만 스코프해서 사용합니다.
+ * Notion 유래(--fg-color/--bg-color/--notion-*) 스케일을 걷어내고, 사이트 팔레트
+ * (#fafaf8 / #0f0f0e)에 정렬된 표면·보더·뮤트·액센트·알림 색을 PostBody에만 스코프해
+ * 사용합니다. 인라인 코드만 의도적으로 빨간 계열(--pb-inline-code)을 유지합니다.
  */
 .post-body {
+  --pb-sans:
+    var(--font-pretendard), ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --pb-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+
   --pb-text: var(--color-text);
   --pb-muted: rgba(0, 0, 0, 0.56);
   --pb-faint: rgba(0, 0, 0, 0.4);
-  --pb-surface: #f5f5f3;
-  --pb-surface-2: #ececea;
   --pb-border: rgba(0, 0, 0, 0.1);
   --pb-border-strong: rgba(0, 0, 0, 0.16);
+  --pb-fill-subtle: rgba(0, 0, 0, 0.03);
+  --pb-surface: #f5f5f3;
+  --pb-surface-2: #ececea;
+
   --pb-accent: #2563eb;
   --pb-accent-soft: rgba(37, 99, 235, 0.12);
   --pb-inline-code: #e5484d;
   --pb-success: #16a34a;
+  --pb-selection: rgba(37, 99, 235, 0.24);
+
+  --pb-alert-note: #2563eb;
+  --pb-alert-tip: #16a34a;
+  --pb-alert-important: #7c3aed;
+  --pb-alert-warning: #d97706;
+  --pb-alert-caution: #dc2626;
+  --pb-alert-note-bg: rgba(37, 99, 235, 0.08);
+  --pb-alert-tip-bg: rgba(22, 163, 74, 0.1);
+  --pb-alert-important-bg: rgba(124, 58, 237, 0.08);
+  --pb-alert-warning-bg: rgba(217, 119, 6, 0.1);
+  --pb-alert-caution-bg: rgba(220, 38, 38, 0.08);
 }
 
 [data-theme='dark'] .post-body,
 .dark-mode .post-body {
   --pb-muted: rgba(255, 255, 255, 0.56);
   --pb-faint: rgba(255, 255, 255, 0.42);
-  --pb-surface: rgba(255, 255, 255, 0.05);
-  --pb-surface-2: rgba(255, 255, 255, 0.09);
   --pb-border: rgba(255, 255, 255, 0.12);
   --pb-border-strong: rgba(255, 255, 255, 0.2);
+  --pb-fill-subtle: rgba(255, 255, 255, 0.05);
+  --pb-surface: rgba(255, 255, 255, 0.05);
+  --pb-surface-2: rgba(255, 255, 255, 0.09);
+
   --pb-accent: #6ea8fe;
   --pb-accent-soft: rgba(110, 168, 254, 0.16);
   --pb-inline-code: #ff8785;
   --pb-success: #4ade80;
+  --pb-selection: rgba(110, 168, 254, 0.3);
+
+  --pb-alert-note: #6ea8fe;
+  --pb-alert-tip: #4ade80;
+  --pb-alert-important: #b794f6;
+  --pb-alert-warning: #fbbf24;
+  --pb-alert-caution: #fb7185;
+  --pb-alert-note-bg: rgba(110, 168, 254, 0.14);
+  --pb-alert-tip-bg: rgba(74, 222, 128, 0.14);
+  --pb-alert-important-bg: rgba(183, 148, 246, 0.14);
+  --pb-alert-warning-bg: rgba(251, 191, 36, 0.14);
+  --pb-alert-caution-bg: rgba(251, 113, 133, 0.14);
 }
 
 .post-body {
   width: 100%;
   color: var(--pb-text);
   caret-color: var(--pb-text);
-  font-family: var(--font-pretendard), var(--notion-font), sans-serif;
+  font-family: var(--pb-sans);
   font-size: 1.0625rem;
   line-height: 1.75;
   word-break: break-word;
@@ -104,7 +82,7 @@
 }
 
 .post-body *::selection {
-  background: var(--select-color-1);
+  background: var(--pb-selection);
 }
 
 .post-body > * {
@@ -414,7 +392,7 @@
   border-radius: 0.3125rem;
   background: var(--pb-surface);
   color: var(--pb-inline-code);
-  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-family: var(--pb-mono);
   font-size: 0.85em;
   word-break: break-word;
 }
@@ -436,7 +414,7 @@
   border-radius: 0.5rem;
   background: var(--pb-surface);
   color: var(--pb-text);
-  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-family: var(--pb-mono);
   font-size: 0.875rem;
   line-height: 1.6;
   tab-size: 2;
@@ -462,7 +440,7 @@
 }
 
 .post-body .code-block-language {
-  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-family: var(--pb-mono);
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -608,7 +586,7 @@
 }
 
 .post-body .markdown-image-trigger:focus-visible {
-  outline: 0.125rem solid var(--fg-color-6);
+  outline: 0.125rem solid var(--pb-text);
   outline-offset: 0.1875rem;
 }
 
@@ -771,11 +749,11 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: space-between;
-  border: 0.0625rem solid var(--fg-color-1);
+  border: 0.0625rem solid var(--pb-border-strong);
   border-radius: 0.375rem;
   background: transparent;
   box-shadow: none;
-  color: var(--fg-color);
+  color: var(--pb-text);
   cursor: pointer;
   text-decoration: none;
   opacity: 1;
@@ -788,8 +766,8 @@
 .post-body .reference-card:hover {
   border-color: transparent;
   box-shadow:
-    0 0 0 0.0625rem var(--fg-color-2),
-    0 0.1875rem 0.75rem var(--fg-color-1);
+    0 0 0 0.0625rem var(--pb-faint),
+    0 0.1875rem 0.75rem var(--pb-border-strong);
   opacity: 1;
 }
 
@@ -800,8 +778,8 @@
   border-radius: 0.4375rem;
   padding: 0.3rem;
   object-fit: contain;
-  background: var(--bg-color-0);
-  box-shadow: inset 0 0 0 0.0625rem var(--fg-color-0);
+  background: var(--pb-surface-2);
+  box-shadow: inset 0 0 0 0.0625rem var(--pb-border);
 }
 
 .post-body .reference-card-content {
@@ -814,7 +792,7 @@
 
 .post-body .reference-card-title {
   display: block;
-  color: var(--fg-color);
+  color: var(--pb-text);
   font-size: 0.95rem;
   font-weight: 600;
   line-height: 1.4;
@@ -823,7 +801,7 @@
 
 .post-body .reference-card-source {
   display: block;
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
   font-size: 0.8125rem;
   line-height: 1.35;
   overflow-wrap: anywhere;
@@ -833,25 +811,25 @@
   flex: 0 0 auto;
   width: 0.95rem;
   height: 0.95rem;
-  color: var(--fg-color-3);
+  color: var(--pb-muted);
 }
 
 .post-body .markdown-alert {
-  --markdown-alert-border: var(--fg-color-0);
-  --markdown-alert-bg: var(--bg-color-1);
+  --pb-alert-border: var(--pb-border);
+  --pb-alert-bg: var(--pb-surface);
 
   display: block;
   width: 100%;
   margin: 0.25rem 0;
   padding: 0.75rem 1rem 0.75rem 0.75rem;
-  border: 0.0625rem solid var(--markdown-alert-border);
+  border: 0.0625rem solid var(--pb-alert-border);
   border-radius: 0.1875rem;
-  background: var(--markdown-alert-bg);
+  background: var(--pb-alert-bg);
 }
 
 [data-theme='dark'] .post-body .markdown-alert,
 .dark-mode .post-body .markdown-alert {
-  border-color: var(--bg-color-2);
+  border-color: var(--pb-surface-2);
 }
 
 .post-body .markdown-alert p {
@@ -864,7 +842,7 @@
   gap: 0.375rem;
   align-items: center;
   margin-bottom: 0.45rem;
-  color: var(--fg-color);
+  color: var(--pb-text);
   font-weight: 700;
   line-height: 1.4;
 }
@@ -883,48 +861,48 @@
 }
 
 .post-body .markdown-alert-note .markdown-alert-title {
-  color: var(--notion-blue);
+  color: var(--pb-alert-note);
 }
 
 .post-body .markdown-alert-note {
-  --markdown-alert-border: rgba(11, 110, 153, 0.22);
-  --markdown-alert-bg: var(--markdown-alert-note-bg);
+  --pb-alert-border: rgba(11, 110, 153, 0.22);
+  --pb-alert-bg: var(--pb-alert-note-bg);
 }
 
 .post-body .markdown-alert-tip .markdown-alert-title {
-  color: var(--notion-teal);
+  color: var(--pb-alert-tip);
 }
 
 .post-body .markdown-alert-tip {
-  --markdown-alert-border: rgba(77, 100, 97, 0.22);
-  --markdown-alert-bg: var(--markdown-alert-tip-bg);
+  --pb-alert-border: rgba(77, 100, 97, 0.22);
+  --pb-alert-bg: var(--pb-alert-tip-bg);
 }
 
 .post-body .markdown-alert-important .markdown-alert-title {
-  color: var(--notion-purple);
+  color: var(--pb-alert-important);
 }
 
 .post-body .markdown-alert-important {
-  --markdown-alert-border: rgba(105, 64, 165, 0.22);
-  --markdown-alert-bg: var(--markdown-alert-important-bg);
+  --pb-alert-border: rgba(105, 64, 165, 0.22);
+  --pb-alert-bg: var(--pb-alert-important-bg);
 }
 
 .post-body .markdown-alert-warning .markdown-alert-title {
-  color: var(--notion-yellow);
+  color: var(--pb-alert-warning);
 }
 
 .post-body .markdown-alert-warning {
-  --markdown-alert-border: rgba(223, 171, 1, 0.26);
-  --markdown-alert-bg: var(--markdown-alert-warning-bg);
+  --pb-alert-border: rgba(223, 171, 1, 0.26);
+  --pb-alert-bg: var(--pb-alert-warning-bg);
 }
 
 .post-body .markdown-alert-caution .markdown-alert-title {
-  color: var(--notion-red);
+  color: var(--pb-alert-caution);
 }
 
 .post-body .markdown-alert-caution {
-  --markdown-alert-border: rgba(224, 62, 62, 0.22);
-  --markdown-alert-bg: var(--markdown-alert-caution-bg);
+  --pb-alert-border: rgba(224, 62, 62, 0.22);
+  --pb-alert-bg: var(--pb-alert-caution-bg);
 }
 
 .post-body .katex-display {
@@ -935,23 +913,37 @@
   overflow-y: hidden;
 }
 
-.post-body .mermaid {
+/*
+ * mermaid 다이어그램은 Shadow DOM 안에서 렌더되어 페이지 CSS가 새어들지 않습니다
+ * (색 씻김·글자 잘림 방지). 여기서는 컨테이너(카드)만 스타일합니다. mermaid 기본
+ * 팔레트가 잘 보이도록 라이트/다크 공통으로 밝은 배경 카드에 얹습니다. 테두리는 없습니다.
+ */
+.post-body .mermaid-figure {
   width: 100%;
-  min-width: min(42rem, 100%);
-  margin: 0.25rem 0;
-  padding: 0.1875rem 0.125rem;
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border-radius: 0.625rem;
+  background: #f8fafc;
   text-align: center;
 }
 
+.post-body .mermaid-figure .mermaid {
+  width: 100%;
+}
+
+.post-body .mermaid-error {
+  color: var(--pb-muted);
+}
+
 .post-body sup[id^='user-content-fnref'] {
-  font-family: var(--font-pretendard), var(--notion-font), sans-serif;
+  font-family: var(--pb-sans);
 }
 
 .post-body .footnotes {
   width: 100%;
   margin-top: 1.5rem;
   padding-top: 1rem;
-  border-top: 0.0625rem solid var(--fg-color-1);
+  border-top: 0.0625rem solid var(--pb-border-strong);
   font-size: 0.95rem;
 }
 

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -9,13 +9,15 @@
     var(--font-pretendard), ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
   --pb-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 
+  /* 글로벌 시맨틱 토큰을 참조해 중복/드리프트를 피합니다(라이트/다크는 globals에서 전환). */
   --pb-text: var(--color-text);
-  --pb-muted: rgba(0, 0, 0, 0.56);
+  --pb-muted: var(--color-text-secondary);
+  --pb-border: var(--color-border);
+  --pb-surface: var(--color-surface);
+  /* PostBody 전용 보조 스케일(글로벌에 대응 토큰이 없는 값) */
   --pb-faint: rgba(0, 0, 0, 0.4);
-  --pb-border: rgba(0, 0, 0, 0.1);
   --pb-border-strong: rgba(0, 0, 0, 0.16);
   --pb-fill-subtle: rgba(0, 0, 0, 0.03);
-  --pb-surface: #f5f5f3;
   --pb-surface-2: #ececea;
 
   --pb-accent: #2563eb;
@@ -38,12 +40,11 @@
 
 [data-theme='dark'] .post-body,
 .dark-mode .post-body {
-  --pb-muted: rgba(255, 255, 255, 0.56);
+  /* --pb-muted/border/surface는 globals의 --color-* 를 참조하므로 여기서 재정의하지
+     않습니다(globals 다크에서 함께 전환). 아래는 PostBody 전용 보조 스케일만 전환. */
   --pb-faint: rgba(255, 255, 255, 0.42);
-  --pb-border: rgba(255, 255, 255, 0.12);
   --pb-border-strong: rgba(255, 255, 255, 0.2);
   --pb-fill-subtle: rgba(255, 255, 255, 0.05);
-  --pb-surface: rgba(255, 255, 255, 0.05);
   --pb-surface-2: rgba(255, 255, 255, 0.09);
 
   --pb-accent: #6ea8fe;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -66,6 +66,10 @@ export interface PostMeta {
    */
   updatedAt?: string;
   /**
+   * 예상 읽기 시간(분). frontmatter의 reading_time에서 옵니다.
+   */
+  readingTime?: number;
+  /**
    * 카테고리 정보
    */
   category: {

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -21,6 +21,21 @@ export function blogLangPathPrefix(lang: PostLang): string {
 }
 
 /**
+ * 읽기 시간(분)을 렌더 언어에 맞춰 표기합니다. kr: "N분", en: "N min", ja: "N分".
+ * 표기가 여러 카드/헤더에 중복되지 않도록 이 공용 formatter로 통일합니다.
+ */
+export function formatReadingTime(minutes: number, lang: PostLang = DEFAULT_POST_LANG): string {
+  switch (lang) {
+    case 'en':
+      return `${minutes} min`;
+    case 'ja':
+      return `${minutes}分`;
+    default:
+      return `${minutes}분`;
+  }
+}
+
+/**
  * 언어별 블로그 목록 경로 (/blog, /en/blog, /ja/blog)
  */
 export function createBlogListHref(lang: PostLang = DEFAULT_POST_LANG): string {


### PR DESCRIPTION
## 요약

블로그 본문 렌더링을 개선합니다.

### 1. 코드 블록 chrome (언어 라벨 + 복사 + 접기)
- `CodeBlock` 클라이언트 컴포넌트 신설: 헤더에 언어 라벨(`YAML`, `TypeScript`…)과 복사 버튼(클릭 시 아이콘 `Copy`→`Check`), 16줄 초과 시 하단에 접기/펼치기 토글. UI 텍스트는 kr/en/ja 로컬라이즈.
- `rehypeCodeBlock` 플러그인이 rehype-pretty-code의 `figure`를 `code-block` 엘리먼트로 치환해 언어·줄수를 전달. shiki 하이라이팅·다크모드는 그대로 유지.

### 2. 이미지 캡션 italic 서식
- 원인: exporter의 mdast `parse→stringify` 왕복이 이미지 alt의 강조/취소선/math 마커를 제거하고 있었습니다.
- exporter에서 원본 소스의 raw alt를 복원하고 stringify 이스케이프를 되돌려 마커를 보존.
- 렌더 시 `remarkImageRawCaption` + `renderInlineMarkdownToReact`로 캡션을 인라인 마크다운으로 렌더링. `MarkdownImageLightbox`의 `caption` 타입을 `ReactNode`로 변경.

### 3. 기타
- smoke 빌드 검사의 코드 마커를 새 `code-block` chrome에 맞게 갱신.

## 참고
- 캡션 내 `$수식$`은 이제 `$` 없이 평문으로 렌더됩니다(기존엔 리터럴 노출). KaTeX 렌더는 별도 후속 가능.

## 검증
`bun run verify` 전체 통과 — types / lint / format / unit(698, 신규 3개 포함) / build / check-content / check-repo / smoke / check-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)