### PR TITLE
feat(blog): 시리즈 기능 + 이미지 최적화 파이프라인 + 포스트 레이아웃 정합

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,13 @@ r3gardless.dev/
 1. `KNOWLEDGE_BASE_PATH`가 가리키는 KNOWLEDGE_BASE 루트를 가장 먼저 읽습니다. 기본 후보에는 `.cache/knowledge-base/KNOWELDGE_BASE`, `.cache/knowledge-base/KNOWLEDGE_BASE`, 레포 상위의 `KNOWLEDGE_BASE`/`KNOWELDGE_BASE`가 포함됩니다.
 2. `scripts/build-content.ts`가 전체 KNOWLEDGE_BASE frontmatter를 스캔합니다.
 3. `publish: true`이고 `layer !== source`인 Markdown만 `content/posts/<slug>/index.md`로 export합니다.
-4. `cover`와 본문 이미지는 `public/content/posts/<slug>/assets/`로 복사하고 Markdown 경로를 절대 public 경로로 재작성합니다. Exported asset URL은 content hash를 포함해야 하며, 같은 파일명으로 이미지를 교체해도 cache가 남지 않아야 합니다.
+4. `cover`와 본문 이미지는 `public/content/posts/<slug>/assets/`로 복사하고 Markdown 경로를 절대 public 경로로 재작성합니다. Exported asset URL은 content hash를 포함해야 하며, 같은 파일명으로 이미지를 교체해도 cache가 남지 않아야 합니다. 래스터 이미지(png/jpg/webp)는 export 시 축소·변환됩니다 — 본문 이미지는 최대 1440(표시폭 720의 레티나 2배) webp로, cover는 OG 크롤러 호환을 위해 원본 포맷을 유지한 채 최대 1536으로 제한합니다. 비율 유지 축소만 수행하며(crop/업스케일 없음) GIF/SVG는 원본 그대로 복사합니다. content hash에는 변환 파라미터가 포함되어 설정 변경 시에도 cache가 무효화됩니다.
 5. 위키링크와 KNOWLEDGE_BASE 내부 `.md` 링크는 다음 순서로 처리합니다.
    - publish 대상: `/blog/<slug>` 내부 링크
    - 미발행 source + `source_url`: 외부 원문 URL
    - 그 외: 텍스트 강등 및 warning
 6. `scripts/build-post-meta.ts`가 export된 Markdown frontmatter에서 `public/data/postMeta.json`을 만듭니다.
+   - 시리즈(연재물)는 frontmatter `series`(이름, 그룹핑 키는 kr 원문 값)와 `series_order`(1부터, 생략 시 작성일순)로 정의합니다. 번역본(`index.en.md`/`index.ja.md`)의 `series`는 언어별 표시 이름으로만 쓰입니다.
 7. `scripts/check-links.ts`는 남은 `.md` 상대 링크, 깨진 이미지, 발행 대상 링크 오류를 실패 처리합니다.
 
 KNOWLEDGE_BASE 원본은 읽기 전용입니다. 이 레포의 파이프라인은 generated output만 쓰며, KNOWLEDGE_BASE 파일을 수정하지 않습니다. 예외는 마이그레이션 회고 노트 1건 추가가 명시된 작업뿐입니다.

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "jsdom": "^29.0.1",
         "lint-staged": "^17.0.4",
         "prettier": "^3.8.1",
+        "sharp": "^0.35.3",
         "storybook": "^10.3.1",
         "styled-jsx": "^5.1.7",
         "tailwindcss": "^4.2.2",
@@ -155,7 +156,7 @@
 
     "@emnapi/core": ["@emnapi/core@1.4.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.2", "tslib": "^2.4.0" } }, "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.0.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA=="],
 
@@ -243,55 +244,59 @@
 
     "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
 
-    "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
 
@@ -1735,7 +1740,7 @@
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -2191,6 +2196,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "next/styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "node-abi/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
@@ -2211,7 +2218,7 @@
 
     "rehype-katex/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
-    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -2363,6 +2370,58 @@
 
     "mdast-util-wiki-link/mdast-util-to-markdown/zwitch": ["zwitch@1.0.5", "", {}, "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="],
 
+    "next/sharp/@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+
+    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "next/sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "typescript-eslint/@typescript-eslint/eslint-plugin/@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.46.4", "", { "dependencies": { "@typescript-eslint/types": "8.46.4", "@typescript-eslint/visitor-keys": "8.46.4" } }, "sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA=="],
@@ -2502,6 +2561,8 @@
     "mdast-util-wiki-link/mdast-util-to-markdown/parse-entities/is-decimal": ["is-decimal@1.0.4", "", {}, "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="],
 
     "mdast-util-wiki-link/mdast-util-to-markdown/parse-entities/is-hexadecimal": ["is-hexadecimal@1.0.4", "", {}, "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="],
+
+    "next/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.46.4", "", {}, "sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w=="],
 

--- a/docs/REPO_GUIDE.md
+++ b/docs/REPO_GUIDE.md
@@ -37,6 +37,8 @@ r3gardless.dev/
 - `KNOWLEDGE_BASE_PATH`는 repo root 또는 `KNOWELDGE_BASE`/`KNOWLEDGE_BASE` 하위 폴더 모두 허용합니다.
 - 발행은 `publish: true`이고 `layer !== source`인 Markdown만 허용합니다.
 - cover 필드는 `cover`만 사용합니다. 본문 이미지와 cover는 `public/content/posts/<slug>/assets/`로 복사되어 content hash가 포함된 절대 public 경로로 재작성됩니다.
+- 래스터 이미지(png/jpg/webp)는 export 시 비율 유지 축소됩니다. 본문 이미지는 최대 1440(표시폭 720의 레티나 2배) webp 변환, cover는 원본 포맷 유지에 최대 1536 제한입니다(OG 크롤러 호환). GIF/SVG는 원본 복사이며, content hash에 변환 파라미터가 포함되어 설정 변경 시 cache가 무효화됩니다.
+- 시리즈(연재물)는 frontmatter `series`(이름)와 `series_order`(1부터, 생략 시 작성일순)로 정의합니다. 그룹핑 키는 kr 원문 `series` 값이고, 번역본(`index.en.md`/`index.ja.md`)의 `series`는 언어별 표시 이름으로만 쓰입니다. 시리즈는 포스트 상세의 시리즈 박스, 사이드바 목록/`?series=` 필터, 검색, 이전/다음 내비게이션(시리즈 순서 우선)에 반영됩니다.
 - `category`는 frontmatter 값을 우선합니다. 없을 때만 `.../<category>/wiki/...` 경로에서 파생합니다. `type: concept` 같은 KNOWLEDGE_BASE 타입을 블로그 category로 쓰지 않습니다.
 - KNOWLEDGE_BASE 내부 `.md` 링크와 wikilink는 발행 글이면 `/blog/<slug>`, source 노트면 `source_url`/`archived_url`, 그 외에는 텍스트 강등입니다.
 - raw/source 원문은 절대 `content/posts/`로 export하지 않습니다.
@@ -51,6 +53,7 @@ r3gardless.dev/
 - 구분은 얇은 border, spacing, typography hierarchy를 우선합니다. 중첩 카드, 과한 glass, gradient/orb 장식은 피합니다.
 - 카드 radius는 기존 컴포넌트 호환 외에는 작게 유지합니다. 읽기 본문은 Notion에 가까운 1rem/1.6 line-height를 유지합니다.
 - 블로그 본문 CSS는 `src/styles/markdown.css`의 `.post-body` 표준 태그 스타일이 기준입니다.
+- 포스트 상세는 xl에서 본문 768 + ToC 256 = 1024 그리드입니다. 커버(헤더/PostCard 썸네일)는 1.91:1(OG 표준) 반응형 비율 박스에 크롭 없이 늘려 채웁니다.
 - 일반 UI 아이콘은 `lucide-react`, GitHub/LinkedIn 같은 브랜드 아이콘은 `react-icons` 브랜드 팩을 씁니다.
 
 ## About 방향

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "jsdom": "^29.0.1",
     "lint-staged": "^17.0.4",
     "prettier": "^3.8.1",
+    "sharp": "^0.35.3",
     "storybook": "^10.3.1",
     "styled-jsx": "^5.1.7",
     "tailwindcss": "^4.2.2",

--- a/scripts/build-content.ts
+++ b/scripts/build-content.ts
@@ -6,6 +6,7 @@ import {
   buildContentIndex,
   createContentLinkMaps,
   exportPublishedPost,
+  flushPendingImageExports,
 } from '../src/libs/content/index.js';
 import type { ContentDiagnostic } from '../src/libs/content/index.js';
 import {
@@ -51,7 +52,7 @@ function writeLinkIndex(index: ReturnType<typeof buildContentIndex>) {
   fs.writeFileSync(LINK_INDEX_PATH, JSON.stringify(data, null, 2), 'utf8');
 }
 
-function main() {
+async function main() {
   const kbRoot = resolveKbPath();
   const contentRoot = resolveContentRoot();
   const publicRoot = resolvePublicRoot();
@@ -71,6 +72,9 @@ function main() {
     diagnostics.push(...exported.diagnostics);
   }
 
+  // 래스터 이미지 축소·webp 변환 작업 실행 (copyAsset이 큐에 쌓은 작업)
+  const convertedImages = await flushPendingImageExports();
+
   writeLinkIndex(index);
   reportDiagnostics(diagnostics);
 
@@ -80,8 +84,11 @@ function main() {
   }
 
   console.log(
-    `Exported ${index.publishedNotes.length} published posts (${index.publishedVariants.length} language variants).`,
+    `Exported ${index.publishedNotes.length} published posts (${index.publishedVariants.length} language variants, ${convertedImages} images resized).`,
   );
 }
 
-main();
+main().catch(error => {
+  console.error(`Content build failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -263,9 +263,7 @@ function checkMarkdownLinksAndImages(
 
     // 본문 래스터 이미지는 export 파이프라인이 webp로 변환해야 합니다 (GIF/SVG 제외).
     if (isPublicContentAssetPath(image.url) && /\.(png|jpe?g)$/i.test(image.url)) {
-      errors.push(
-        `${relativeFile}: raster body images must be exported as webp: ${image.url}`,
-      );
+      errors.push(`${relativeFile}: raster body images must be exported as webp: ${image.url}`);
     }
   });
 }

--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -260,6 +260,13 @@ function checkMarkdownLinksAndImages(
         `${relativeFile}: exported image asset must include a content hash for cache busting: ${image.url}`,
       );
     }
+
+    // 본문 래스터 이미지는 export 파이프라인이 webp로 변환해야 합니다 (GIF/SVG 제외).
+    if (isPublicContentAssetPath(image.url) && /\.(png|jpe?g)$/i.test(image.url)) {
+      errors.push(
+        `${relativeFile}: raster body images must be exported as webp: ${image.url}`,
+      );
+    }
   });
 }
 

--- a/src/__tests__/libs/blogPages/listPage.test.tsx
+++ b/src/__tests__/libs/blogPages/listPage.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { LocalizedBlogListPage } from '@/libs/blogPages/listPage';
+import type { PostMeta } from '@/types/blog';
+import type { SeriesSummary } from '@/utils/blog';
+
+const staticDataMocks = vi.hoisted(() => ({
+  posts: [] as PostMeta[],
+}));
+
+vi.mock('@/libs/staticPostData', () => ({
+  getPostListWithStaticFallback: () => Promise.resolve(staticDataMocks.posts),
+}));
+
+vi.mock('@/app/blog/BlogPageClient', () => ({
+  default: ({
+    initialSeries,
+    initialCategories,
+  }: {
+    initialSeries?: SeriesSummary[];
+    initialCategories: string[];
+  }) => (
+    <div>
+      <div data-testid="categories">{initialCategories.join(',')}</div>
+      <ul data-testid="series">
+        {(initialSeries ?? []).map(item => (
+          <li key={item.name}>{`${item.name}:${item.count}`}</li>
+        ))}
+      </ul>
+    </div>
+  ),
+}));
+
+const createPost = (overrides: Partial<PostMeta>): PostMeta => ({
+  pageId: 'post',
+  id: 1,
+  title: 'Post',
+  createdAt: 'May 05, 2026',
+  category: { text: 'Vector Search', color: 'purple' },
+  tags: [],
+  slug: 'post',
+  encodedSlug: 'post',
+  ...overrides,
+});
+
+describe('LocalizedBlogListPage', () => {
+  it('시리즈 요약 목록을 BlogPageClient에 전달한다', async () => {
+    staticDataMocks.posts = [
+      createPost({ id: 1, slug: 'a', series: { name: 'ANN 논문리뷰', order: 1 } }),
+      createPost({ id: 2, slug: 'b', series: { name: 'ANN 논문리뷰', order: 2 } }),
+      createPost({ id: 3, slug: 'c' }),
+    ];
+
+    render(await LocalizedBlogListPage({ lang: 'kr' }));
+
+    expect(screen.getByTestId('series')).toHaveTextContent('ANN 논문리뷰:2');
+  });
+
+  it('en 페이지에서는 번역된 시리즈 이름으로 요약을 만든다', async () => {
+    staticDataMocks.posts = [
+      createPost({
+        id: 1,
+        slug: 'a',
+        series: { name: 'ANN 논문리뷰', order: 1 },
+        languages: ['kr', 'en'],
+        translations: { en: { title: 'Post (EN)', seriesName: 'ANN Paper Review' } },
+      }),
+    ];
+
+    render(await LocalizedBlogListPage({ lang: 'en' }));
+
+    expect(screen.getByTestId('series')).toHaveTextContent('ANN Paper Review:1');
+    expect(screen.getByTestId('series')).not.toHaveTextContent('ANN 논문리뷰');
+  });
+});

--- a/src/__tests__/libs/blogPages/postPage.test.tsx
+++ b/src/__tests__/libs/blogPages/postPage.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { LocalizedPostPage } from '@/libs/blogPages/postPage';
+import type { PostMeta } from '@/types/blog';
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async importOriginal => {
+  const actual = (await importOriginal()) as typeof import('node:fs') & {
+    default: typeof import('node:fs');
+  };
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      existsSync: fsMocks.existsSync,
+      readFileSync: fsMocks.readFileSync,
+    },
+  };
+});
+
+const staticDataMocks = vi.hoisted(() => ({
+  posts: [] as PostMeta[],
+}));
+
+vi.mock('@/libs/staticPostData', () => ({
+  getPostListWithStaticFallback: () => Promise.resolve(staticDataMocks.posts),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('NOT_FOUND');
+  },
+}));
+
+// PostBody 등 async 서버 컴포넌트 렌더를 피하고, postPage가 계산해 넘기는 props를 검증한다
+vi.mock('@/components/templates/PostTemplate', () => ({
+  PostTemplate: ({
+    post,
+    seriesPosts,
+    prevPost,
+    nextPost,
+  }: {
+    post: PostMeta;
+    seriesPosts?: Array<{ id: number; title: string; href: string }>;
+    prevPost?: { title: string };
+    nextPost?: { title: string };
+  }) => (
+    <div>
+      <h1>{post.title}</h1>
+      {post.series && seriesPosts && seriesPosts.length > 1 && (
+        <section data-testid="series">
+          <span>{post.series.name}</span>
+          <span>{`${seriesPosts.findIndex(p => p.id === post.id) + 1} / ${seriesPosts.length}`}</span>
+        </section>
+      )}
+      {prevPost && <span data-testid="prev">{prevPost.title}</span>}
+      {nextPost && <span data-testid="next">{nextPost.title}</span>}
+    </div>
+  ),
+}));
+
+const createPost = (overrides: Partial<PostMeta>): PostMeta => ({
+  pageId: 'post',
+  id: 1,
+  title: 'Post',
+  description: 'Description',
+  createdAt: 'May 05, 2026',
+  category: { text: 'Vector Search', color: 'purple' },
+  tags: ['Paper Review'],
+  slug: 'post',
+  encodedSlug: 'post',
+  ...overrides,
+});
+
+describe('LocalizedPostPage', () => {
+  beforeEach(() => {
+    fsMocks.existsSync.mockReset();
+    fsMocks.readFileSync.mockReset();
+    // 포스트 markdown은 존재, contentLinkIndex는 없음(빈 링크맵)으로 동작
+    fsMocks.existsSync.mockImplementation((filePath: string) =>
+      String(filePath).includes('content/posts'),
+    );
+    fsMocks.readFileSync.mockReturnValue('# 본문 제목\n\n본문 내용입니다.');
+  });
+
+  it('시리즈 포스트는 시리즈 박스와 시리즈 순서 이전/다음 내비게이션을 렌더링한다', async () => {
+    // 전체 목록 순서(최신순)와 시리즈 순서(작성일순)가 다르도록 구성:
+    // 시리즈 밖의 최신 글(unrelated)이 사이에 끼어 있어도 내비게이션은 시리즈 순서를 따라야 한다
+    staticDataMocks.posts = [
+      createPost({
+        id: 3,
+        slug: 'series-2',
+        title: '시리즈 2편',
+        createdAt: 'May 07, 2026',
+        series: { name: 'ANN 논문리뷰' },
+        publishedAt: '2026-05-07',
+      }),
+      createPost({ id: 2, slug: 'unrelated', title: '무관한 글', createdAt: 'May 06, 2026' }),
+      createPost({
+        id: 1,
+        slug: 'series-1',
+        title: '시리즈 1편',
+        createdAt: 'May 05, 2026',
+        series: { name: 'ANN 논문리뷰' },
+        publishedAt: '2026-05-05',
+      }),
+    ];
+
+    render(await LocalizedPostPage({ slug: 'series-1', lang: 'kr' }));
+
+    // 시리즈 박스: 이름과 현재 위치 1 / 2
+    expect(screen.getByText('ANN 논문리뷰')).toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument();
+
+    // 이전/다음 내비게이션이 시간순(무관한 글)이 아닌 시리즈 순서(2편)를 따른다
+    expect(screen.getByTestId('next')).toHaveTextContent('시리즈 2편');
+    expect(screen.queryByText('무관한 글')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('prev')).not.toBeInTheDocument();
+  });
+
+  it('시리즈가 없는 포스트는 시리즈 박스 없이 전체 목록 순서 내비게이션을 쓴다', async () => {
+    staticDataMocks.posts = [
+      createPost({ id: 2, slug: 'newer', title: '더 최신 글', createdAt: 'May 06, 2026' }),
+      createPost({ id: 1, slug: 'target', title: '대상 글', createdAt: 'May 05, 2026' }),
+    ];
+
+    render(await LocalizedPostPage({ slug: 'target', lang: 'kr' }));
+
+    expect(screen.queryByTestId('series')).not.toBeInTheDocument();
+    // 전체 목록(최신순)에서 바로 앞 항목이 prev로 이어진다
+    expect(screen.getByTestId('prev')).toHaveTextContent('더 최신 글');
+  });
+
+  it('없는 slug는 notFound 처리한다', async () => {
+    staticDataMocks.posts = [createPost({ id: 1, slug: 'exists' })];
+
+    await expect(LocalizedPostPage({ slug: 'missing', lang: 'kr' })).rejects.toThrow('NOT_FOUND');
+  });
+});

--- a/src/__tests__/libs/content/exporter.test.ts
+++ b/src/__tests__/libs/content/exporter.test.ts
@@ -4,7 +4,12 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildContentIndex, exportPublishedPost, transformMarkdownForExport } from '@/libs/content';
+import {
+  buildContentIndex,
+  exportPublishedPost,
+  flushPendingImageExports,
+  transformMarkdownForExport,
+} from '@/libs/content';
 
 const fixtureKbRoot = path.join(process.cwd(), 'tests/fixtures/kb/KNOWELDGE_BASE');
 const publishedSlug = '2026-06-21-published-note';
@@ -121,6 +126,123 @@ describe('content exporter', () => {
     expect(fs.readFileSync(path.join(exportedAssetsDir, exportedDiagram!), 'utf8')).not.toContain(
       'preserveAspectRatio="none"',
     );
+  });
+
+  it('resizes raster body images to webp and keeps cover format with capped width', async () => {
+    const { default: sharp } = await import('sharp');
+
+    // 큰 래스터 이미지(2000px)를 본문과 커버로 쓰는 임시 KB를 구성한다
+    const kbRoot = path.join(tempRoot, 'KB');
+    const noteDir = path.join(kbRoot, 'dev', 'blog', 'wiki');
+    fs.mkdirSync(path.join(noteDir, 'assets'), { recursive: true });
+    await sharp({
+      create: { width: 2000, height: 1000, channels: 3, background: { r: 180, g: 120, b: 60 } },
+    })
+      .png()
+      .toFile(path.join(noteDir, 'assets', 'photo.png'));
+    fs.writeFileSync(
+      path.join(noteDir, 'raster-note.md'),
+      [
+        '---',
+        'layer: wiki',
+        'title: Raster Note',
+        'publish: true',
+        'slug: raster-note',
+        'added: 2026-07-10',
+        'cover: ./assets/photo.png',
+        '---',
+        '',
+        '# Raster Note',
+        '',
+        '![Photo](./assets/photo.png)',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const index = buildContentIndex(kbRoot);
+    const paths = createExportPaths();
+    for (const note of index.publishedNotes) {
+      exportPublishedPost(note, index, paths);
+    }
+    const converted = await flushPendingImageExports();
+    expect(converted).toBeGreaterThanOrEqual(2);
+
+    const slug = '2026-07-10-raster-note';
+    const markdown = fs.readFileSync(path.join(paths.contentRoot, slug, 'index.md'), 'utf8');
+    // 본문 이미지는 webp로, 커버는 원본 포맷(png)을 유지한다
+    expect(markdown).toMatch(
+      new RegExp(`!\\[Photo\\]\\(/content/posts/${slug}/assets/photo\\.[a-f0-9]{12}\\.webp\\)`),
+    );
+    expect(markdown).toMatch(
+      new RegExp(`cover: /content/posts/${slug}/assets/photo\\.[a-f0-9]{12}\\.png`),
+    );
+
+    const assetsDir = path.join(tempRoot, 'public/content/posts', slug, 'assets');
+    const bodyFile = fs.readdirSync(assetsDir).find(name => name.endsWith('.webp'));
+    const coverFile = fs.readdirSync(assetsDir).find(name => name.endsWith('.png'));
+    expect(bodyFile).toBeDefined();
+    expect(coverFile).toBeDefined();
+
+    // 폭 상한: 본문 1440(720의 레티나 2배), 커버 1536(768의 2배). 비율 유지(crop 없음).
+    const bodyMeta = await sharp(path.join(assetsDir, bodyFile!)).metadata();
+    expect(bodyMeta.format).toBe('webp');
+    expect(bodyMeta.width).toBe(1440);
+    expect(bodyMeta.height).toBe(720);
+    const coverMeta = await sharp(path.join(assetsDir, coverFile!)).metadata();
+    expect(coverMeta.format).toBe('png');
+    expect(coverMeta.width).toBe(1536);
+    expect(coverMeta.height).toBe(768);
+  });
+
+  it('keeps small raster images at their original size', async () => {
+    const { default: sharp } = await import('sharp');
+
+    const kbRoot = path.join(tempRoot, 'KB');
+    const noteDir = path.join(kbRoot, 'dev', 'blog', 'wiki');
+    fs.mkdirSync(path.join(noteDir, 'assets'), { recursive: true });
+    await sharp({
+      create: { width: 400, height: 300, channels: 3, background: { r: 20, g: 40, b: 80 } },
+    })
+      .png()
+      .toFile(path.join(noteDir, 'assets', 'small.png'));
+    fs.writeFileSync(
+      path.join(noteDir, 'small-note.md'),
+      [
+        '---',
+        'layer: wiki',
+        'title: Small Note',
+        'publish: true',
+        'slug: small-note',
+        'added: 2026-07-11',
+        '---',
+        '',
+        '# Small Note',
+        '',
+        '![Small](./assets/small.png)',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const index = buildContentIndex(kbRoot);
+    const paths = createExportPaths();
+    for (const note of index.publishedNotes) {
+      exportPublishedPost(note, index, paths);
+    }
+    await flushPendingImageExports();
+
+    const assetsDir = path.join(
+      tempRoot,
+      'public/content/posts',
+      '2026-07-11-small-note',
+      'assets',
+    );
+    const bodyFile = fs.readdirSync(assetsDir).find(name => name.endsWith('.webp'));
+    expect(bodyFile).toBeDefined();
+
+    // 원본(400px)이 상한보다 작으면 업스케일하지 않는다
+    const meta = await sharp(path.join(assetsDir, bodyFile!)).metadata();
+    expect(meta.width).toBe(400);
+    expect(meta.height).toBe(300);
   });
 
   it('exports each published note to content/posts/<slug>/index.md', () => {

--- a/src/__tests__/libs/content/postMeta.test.ts
+++ b/src/__tests__/libs/content/postMeta.test.ts
@@ -85,9 +85,11 @@ describe('post metadata from exported content', () => {
     expect(posts[0].title).toBe('Published Note');
     expect(posts[0].description).toBe('A published fixture note.');
     expect(posts[0].languages).toEqual(['kr', 'en', 'ja']);
+    expect(posts[0].series).toEqual({ name: '픽스처 시리즈', order: 2 });
     expect(posts[0].translations?.en).toEqual({
       title: 'Published Note (EN)',
       description: 'A published fixture note translated into English.',
+      seriesName: 'Fixture Series',
     });
     expect(posts[0].translations?.ja).toMatchObject({
       title: '公開ノート (JP)',

--- a/src/__tests__/libs/content/postMeta.test.ts
+++ b/src/__tests__/libs/content/postMeta.test.ts
@@ -99,6 +99,51 @@ describe('post metadata from exported content', () => {
     });
   });
 
+  it('reads series frontmatter with per-language display names', () => {
+    const contentRoot = path.join(tempRoot, 'content/posts');
+    const slug = '2026-07-01-series-note';
+    const postDir = path.join(contentRoot, slug);
+    fs.mkdirSync(postDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(postDir, 'index.md'),
+      [
+        '---',
+        'title: 시리즈 노트',
+        'publish: true',
+        'added: 2026-07-01',
+        'series: ANN 논문 리뷰',
+        'series_order: 2',
+        '---',
+        '',
+        '본문',
+      ].join('\n'),
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(postDir, 'index.en.md'),
+      [
+        '---',
+        'title: Series Note (EN)',
+        'lang: en',
+        'series: ANN Paper Review',
+        '---',
+        '',
+        'Body',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const posts = readPostMetaFromContent(contentRoot);
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].series).toEqual({ name: 'ANN 논문 리뷰', order: 2 });
+    expect(posts[0].translations?.en).toMatchObject({
+      title: 'Series Note (EN)',
+      seriesName: 'ANN Paper Review',
+    });
+  });
+
   it('marks kr-only posts without translations', () => {
     const index = buildContentIndex(fixtureKbRoot);
     const contentRoot = path.join(tempRoot, 'content/posts');

--- a/src/__tests__/utils/blog.test.ts
+++ b/src/__tests__/utils/blog.test.ts
@@ -14,7 +14,9 @@ import {
   formatPostDateTimeKST,
   getPostCategories,
   getPostLanguages,
+  getPostSeriesList,
   getPostTags,
+  getSeriesPosts,
   getTableOfContents,
   isAllPostsCategory,
   localizePostMeta,
@@ -95,6 +97,61 @@ describe('Blog Utils', () => {
     });
   });
 
+  describe('getSeriesPosts', () => {
+    const seriesPost = (id: number, createdAt: string, series?: PostMeta['series']): PostMeta => ({
+      ...basePost,
+      id,
+      slug: `post-${id}`,
+      encodedSlug: `post-${id}`,
+      createdAt,
+      series,
+    });
+
+    it('같은 시리즈의 포스트만 골라 작성일 오름차순으로 정렬한다', () => {
+      const posts = [
+        seriesPost(1, '2026-03-01', { name: 'A 시리즈' }),
+        seriesPost(2, '2026-01-01', { name: 'A 시리즈' }),
+        seriesPost(3, '2026-02-01', { name: 'B 시리즈' }),
+        seriesPost(4, '2026-02-01'),
+      ];
+
+      expect(getSeriesPosts(posts, 'A 시리즈').map(p => p.id)).toEqual([2, 1]);
+    });
+
+    it('series.order가 있으면 order 오름차순을 우선한다', () => {
+      const posts = [
+        seriesPost(1, '2026-01-01', { name: 'A 시리즈', order: 3 }),
+        seriesPost(2, '2026-02-01', { name: 'A 시리즈', order: 1 }),
+        seriesPost(3, '2026-03-01', { name: 'A 시리즈', order: 2 }),
+      ];
+
+      expect(getSeriesPosts(posts, 'A 시리즈').map(p => p.id)).toEqual([2, 3, 1]);
+    });
+
+    it('order가 있는 포스트를 order가 없는 포스트보다 앞에 둔다', () => {
+      const posts = [
+        seriesPost(1, '2026-01-01', { name: 'A 시리즈' }),
+        seriesPost(2, '2026-02-01', { name: 'A 시리즈', order: 1 }),
+      ];
+
+      expect(getSeriesPosts(posts, 'A 시리즈').map(p => p.id)).toEqual([2, 1]);
+    });
+
+    it('포스트 목록에서 시리즈 요약 목록을 파생한다', () => {
+      const posts = [
+        seriesPost(1, '2026-01-01', { name: 'A 시리즈' }),
+        seriesPost(2, '2026-02-01', { name: 'B 시리즈' }),
+        seriesPost(3, '2026-03-01', { name: 'A 시리즈' }),
+        seriesPost(4, '2026-04-01'),
+      ];
+
+      expect(getPostSeriesList(posts)).toEqual([
+        { name: 'A 시리즈', count: 2 },
+        { name: 'B 시리즈', count: 1 },
+      ]);
+    });
+  });
+
   describe('multilingual helpers', () => {
     const translatedPost = {
       ...basePost,
@@ -137,6 +194,30 @@ describe('Blog Utils', () => {
       expect(localizePostMeta(translatedPost, 'kr')).toBe(translatedPost);
       expect(localizePostMeta(translatedPost, 'ja')).toBe(translatedPost);
       expect(localizePostMeta(basePost, 'en')).toBe(basePost);
+    });
+
+    it('번역 seriesName이 있으면 시리즈 표시 이름을 치환한다', () => {
+      const seriesPost = {
+        ...translatedPost,
+        series: { name: 'ANN 논문 리뷰', order: 1 },
+        translations: {
+          en: {
+            title: 'Published Note (EN)',
+            seriesName: 'ANN Paper Review',
+          },
+        },
+      } satisfies PostMeta;
+
+      expect(localizePostMeta(seriesPost, 'en').series).toEqual({
+        name: 'ANN Paper Review',
+        order: 1,
+      });
+      // seriesName이 없는 번역은 kr 시리즈 이름을 유지한다
+      expect(localizePostMeta(translatedPost, 'en').series).toBeUndefined();
+      expect(localizePostMeta(seriesPost, 'kr').series).toEqual({
+        name: 'ANN 논문 리뷰',
+        order: 1,
+      });
     });
   });
 

--- a/src/__tests__/utils/search.test.ts
+++ b/src/__tests__/utils/search.test.ts
@@ -68,6 +68,18 @@ describe('search utils', () => {
     expect(matchesPostSearch(post, 'makefile')).toBe(true);
   });
 
+  it('시리즈 이름을 검색 범위에 포함한다', () => {
+    const post = createPost({
+      title: 'Unrelated Title',
+      description: 'No keyword here.',
+      series: { name: 'ANN 논문 리뷰', order: 1 },
+    });
+
+    expect(matchesPostSearch(post, 'ANN 논문')).toBe(true);
+    expect(matchesPostSearch(post, '논문 리뷰')).toBe(true);
+    expect(matchesPostSearch(createPost({ title: 'Unrelated Title' }), 'ANN 논문')).toBe(false);
+  });
+
   it('포스트 배열을 검색 결과로 필터링한다', () => {
     const posts = [
       createPost({ id: 1, slug: 'pq' }),

--- a/src/app/blog/BlogPageClient.test.tsx
+++ b/src/app/blog/BlogPageClient.test.tsx
@@ -121,4 +121,48 @@ describe('BlogPageClient search filtering', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('Browser File Sync')).not.toBeInTheDocument();
   });
+
+  it('URL의 series 파라미터로 포스트를 필터링한다', async () => {
+    navigationMocks.searchParams = new URLSearchParams('series=ANN 논문 리뷰');
+    const seriesPosts = [
+      createPost({ id: 1, slug: 'pq', series: { name: 'ANN 논문 리뷰', order: 1 } }),
+      createPost({ id: 2, slug: 'browser-file-sync', title: 'Browser File Sync' }),
+    ];
+
+    render(
+      <BlogPageClient
+        initialPosts={seriesPosts}
+        initialCategories={[]}
+        initialSeries={[{ name: 'ANN 논문 리뷰', count: 1 }]}
+        initialTags={[]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('post-count')).toHaveTextContent('1'));
+    expect(
+      screen.getByText('Product Quantization for Nearest Neighbor Search'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Browser File Sync')).not.toBeInTheDocument();
+  });
+
+  it('현재 언어 목록에 없는 series 파라미터는 해제한다 (언어 전환 잔여값)', async () => {
+    // en 페이지로 kr 시리즈 이름이 넘어온 상황: 필터를 풀고 전체를 보여준다
+    navigationMocks.searchParams = new URLSearchParams('series=ANN 논문 리뷰');
+    const seriesPosts = [
+      createPost({ id: 1, slug: 'pq', series: { name: 'ANN Paper Review', order: 1 } }),
+      createPost({ id: 2, slug: 'browser-file-sync', title: 'Browser File Sync' }),
+    ];
+
+    render(
+      <BlogPageClient
+        initialPosts={seriesPosts}
+        initialCategories={[]}
+        initialSeries={[{ name: 'ANN Paper Review', count: 1 }]}
+        initialTags={[]}
+        lang="en"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('post-count')).toHaveTextContent('2'));
+  });
 });

--- a/src/app/blog/BlogPageClient.tsx
+++ b/src/app/blog/BlogPageClient.tsx
@@ -9,11 +9,14 @@ import { BLOG_POSTS_PER_PAGE } from '@/constants/blog';
 import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang, PostMeta } from '@/types/blog';
 import { convertPostsForRendering, createBlogListHref, isAllPostsCategory } from '@/utils/blog';
+import type { SeriesSummary } from '@/utils/blog';
 import { filterPostsBySearch } from '@/utils/search';
 
 interface BlogPageClientProps {
   initialPosts: PostMeta[];
   initialCategories: string[];
+  /** 사이드바에 표시할 시리즈 목록. 비어 있으면 시리즈 섹션을 숨깁니다. */
+  initialSeries?: SeriesSummary[];
   initialTags: string[];
   /** 목록 언어. en/ja이면 포스트 링크와 URL 갱신이 언어 라우트를 사용합니다. */
   lang?: PostLang;
@@ -26,6 +29,7 @@ interface BlogPageClientProps {
 function BlogPageContent({
   initialPosts,
   initialCategories,
+  initialSeries = [],
   initialTags,
   lang = DEFAULT_POST_LANG,
 }: BlogPageClientProps) {
@@ -36,6 +40,7 @@ function BlogPageContent({
   // hydration 불일치를 막기 위해, 초기값은 항상 빈 값으로 두고 useEffect에서 URL 기반으로 갱신
   const [searchValue, setSearchValue] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
+  const [selectedSeries, setSelectedSeries] = useState<string | undefined>(undefined);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [currentPage, setCurrentPage] = useState(1);
@@ -47,11 +52,13 @@ function BlogPageContent({
   useEffect(() => {
     const urlSearch = searchParams.get('search') ?? '';
     const urlCategory = searchParams.get('category') ?? undefined;
+    const urlSeries = searchParams.get('series') ?? undefined;
     const urlTags = searchParams.get('tags')?.split(',').filter(Boolean) ?? [];
 
     startTransition(() => {
       setSearchValue(urlSearch);
       setSelectedCategory(urlCategory);
+      setSelectedSeries(urlSeries);
       setSelectedTags(urlTags);
       setIsHydrated(true);
     });
@@ -71,6 +78,11 @@ function BlogPageContent({
       filtered = filtered.filter(post => post.category.text === selectedCategory);
     }
 
+    // 시리즈 필터링
+    if (selectedSeries) {
+      filtered = filtered.filter(post => post.series?.name === selectedSeries);
+    }
+
     // 태그 필터링
     if (selectedTags.length > 0) {
       filtered = filtered.filter(post =>
@@ -86,7 +98,7 @@ function BlogPageContent({
     });
 
     return filtered;
-  }, [initialPosts, searchValue, selectedCategory, selectedTags, sortDirection]);
+  }, [initialPosts, searchValue, selectedCategory, selectedSeries, selectedTags, sortDirection]);
 
   // 페이지네이션
   const totalPages = Math.ceil(filteredAndSortedPosts.length / postsPerPage);
@@ -97,7 +109,12 @@ function BlogPageContent({
   }, [filteredAndSortedPosts, currentPage, postsPerPage]);
 
   // URL 업데이트 함수
-  const updateURL = (params: { search?: string; category?: string; tags?: string[] }) => {
+  const updateURL = (params: {
+    search?: string;
+    category?: string;
+    series?: string;
+    tags?: string[];
+  }) => {
     if (!isHydrated) return;
 
     const newParams = new URLSearchParams();
@@ -109,6 +126,10 @@ function BlogPageContent({
     const category = params.category;
     if (category && !isAllPostsCategory(category)) {
       newParams.set('category', category);
+    }
+
+    if (params.series) {
+      newParams.set('series', params.series);
     }
 
     if (params.tags && params.tags.length > 0) {
@@ -127,7 +148,12 @@ function BlogPageContent({
   };
 
   const handleSearch = () => {
-    updateURL({ search: searchValue, category: selectedCategory, tags: selectedTags });
+    updateURL({
+      search: searchValue,
+      category: selectedCategory,
+      series: selectedSeries,
+      tags: selectedTags,
+    });
   };
 
   const handleCategoryClick = (category: string) => {
@@ -135,8 +161,20 @@ function BlogPageContent({
     setSelectedCategory(newCategory);
     setCurrentPage(1);
     setSearchValue('');
+    setSelectedSeries(undefined);
     setSelectedTags([]);
     updateURL({ search: undefined, category: newCategory, tags: [] });
+  };
+
+  const handleSeriesClick = (seriesName: string) => {
+    // 선택된 시리즈를 다시 클릭하면 해제
+    const newSeries = seriesName === selectedSeries ? undefined : seriesName;
+    setSelectedSeries(newSeries);
+    setCurrentPage(1);
+    setSearchValue('');
+    setSelectedCategory(undefined);
+    setSelectedTags([]);
+    updateURL({ search: undefined, series: newSeries, tags: [] });
   };
 
   const handleTagClick = (tag: string) => {
@@ -148,7 +186,12 @@ function BlogPageContent({
     }
     setSelectedTags(newTags);
     setCurrentPage(1);
-    updateURL({ search: searchValue, category: selectedCategory, tags: newTags });
+    updateURL({
+      search: searchValue,
+      category: selectedCategory,
+      series: selectedSeries,
+      tags: newTags,
+    });
   };
 
   const handlePostTagClick = (tag: string) => {
@@ -157,17 +200,28 @@ function BlogPageContent({
     setCurrentPage(1);
     updateURL({ search: searchValue, category: undefined, tags: newTags });
     setSelectedCategory(undefined);
+    setSelectedSeries(undefined);
   };
 
   const handleTagRemove = (tag: string) => {
     const newTags = selectedTags.filter(t => t !== tag);
     setSelectedTags(newTags);
-    updateURL({ search: searchValue, category: selectedCategory, tags: newTags });
+    updateURL({
+      search: searchValue,
+      category: selectedCategory,
+      series: selectedSeries,
+      tags: newTags,
+    });
   };
 
   const handleClearAllTags = () => {
     setSelectedTags([]);
-    updateURL({ search: searchValue, category: selectedCategory, tags: [] });
+    updateURL({
+      search: searchValue,
+      category: selectedCategory,
+      series: selectedSeries,
+      tags: [],
+    });
   };
 
   const handleSortChange = (sortBy: 'id', direction: 'asc' | 'desc') => {
@@ -192,8 +246,10 @@ function BlogPageContent({
         }}
         sidebar={{
           categories: initialCategories,
+          series: initialSeries,
           tags: initialTags,
           selectedCategory: undefined,
+          selectedSeries: undefined,
           selectedTags: [],
           lang,
           showMoreCategories: true,
@@ -201,6 +257,7 @@ function BlogPageContent({
           isHidden: false,
           onCategoryClick: () => {},
           onMoreCategoriesClick: () => {},
+          onSeriesClick: () => {},
           onTagClick: () => {},
           onTagRemove: () => {},
           onMoreTagsClick: () => {},
@@ -232,6 +289,7 @@ function BlogPageContent({
       header={{
         searchValue,
         selectedCategory,
+        selectedSeries,
         selectedTags,
         onSearchChange: handleSearchChange,
         onSearch: handleSearch,
@@ -239,8 +297,10 @@ function BlogPageContent({
       }}
       sidebar={{
         categories: initialCategories,
+        series: initialSeries,
         tags: initialTags,
         selectedCategory,
+        selectedSeries,
         selectedTags,
         lang,
         showMoreCategories: true,
@@ -248,6 +308,7 @@ function BlogPageContent({
         isHidden: false,
         onCategoryClick: handleCategoryClick,
         onMoreCategoriesClick: () => {},
+        onSeriesClick: handleSeriesClick,
         onTagClick: handleTagClick,
         onTagRemove: handleTagRemove,
         onMoreTagsClick: () => {},
@@ -284,6 +345,7 @@ function BlogPageContent({
 export default function BlogPageClient({
   initialPosts,
   initialCategories,
+  initialSeries = [],
   initialTags,
   lang = DEFAULT_POST_LANG,
 }: BlogPageClientProps) {
@@ -301,14 +363,17 @@ export default function BlogPageClient({
           }}
           sidebar={{
             categories: initialCategories,
+            series: initialSeries,
             tags: initialTags,
             selectedCategory: undefined,
+            selectedSeries: undefined,
             selectedTags: [],
             showMoreCategories: false,
             showMoreTags: false,
             isHidden: false,
             onCategoryClick: () => {},
             onMoreCategoriesClick: () => {},
+            onSeriesClick: () => {},
             onTagClick: () => {},
             onTagRemove: () => {},
             onMoreTagsClick: () => {},
@@ -333,6 +398,7 @@ export default function BlogPageClient({
       <BlogPageContent
         initialPosts={initialPosts}
         initialCategories={initialCategories}
+        initialSeries={initialSeries}
         initialTags={initialTags}
         lang={lang}
       />

--- a/src/app/blog/BlogPageClient.tsx
+++ b/src/app/blog/BlogPageClient.tsx
@@ -52,7 +52,12 @@ function BlogPageContent({
   useEffect(() => {
     const urlSearch = searchParams.get('search') ?? '';
     const urlCategory = searchParams.get('category') ?? undefined;
-    const urlSeries = searchParams.get('series') ?? undefined;
+    // 시리즈 이름은 언어별로 번역되므로, 현재 언어 목록에 없는 값(다른 언어의 이름 등)은 해제한다
+    const urlSeriesRaw = searchParams.get('series') ?? undefined;
+    const urlSeries =
+      urlSeriesRaw && initialSeries.some(item => item.name === urlSeriesRaw)
+        ? urlSeriesRaw
+        : undefined;
     const urlTags = searchParams.get('tags')?.split(',').filter(Boolean) ?? [];
 
     startTransition(() => {
@@ -62,7 +67,7 @@ function BlogPageContent({
       setSelectedTags(urlTags);
       setIsHydrated(true);
     });
-  }, [searchParams]);
+  }, [searchParams, initialSeries]);
 
   // 필터링 및 정렬된 포스트 목록
   const filteredAndSortedPosts = useMemo(() => {

--- a/src/components/layout/Header/LanguageSwitcher.test.tsx
+++ b/src/components/layout/Header/LanguageSwitcher.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  LanguageSwitcher,
+  langFromPathname,
+  localizedPathname,
+  pathnameWithoutLangPrefix,
+  searchForLanguageSwitch,
+} from './LanguageSwitcher';
+
+const navigationMocks = vi.hoisted(() => ({
+  pathname: '/blog',
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => navigationMocks.pathname,
+}));
+
+describe('LanguageSwitcher helpers', () => {
+  it('경로에서 언어를 파싱한다', () => {
+    expect(langFromPathname('/blog')).toBe('kr');
+    expect(langFromPathname('/en/blog')).toBe('en');
+    expect(langFromPathname('/ja')).toBe('ja');
+  });
+
+  it('언어 prefix를 제거·교체한다', () => {
+    expect(pathnameWithoutLangPrefix('/en/blog')).toBe('/blog');
+    expect(localizedPathname('/blog', 'en')).toBe('/en/blog');
+    expect(localizedPathname('/en/blog', 'kr')).toBe('/blog');
+  });
+
+  it('언어 전환 시 series query만 제거한다 (category/tags/search는 유지)', () => {
+    expect(searchForLanguageSwitch('?series=ANN+%EB%85%BC%EB%AC%B8')).toBe('');
+    expect(searchForLanguageSwitch('?series=ANN&tags=Web,DB&category=Vector+Search')).toBe(
+      '?tags=Web%2CDB&category=Vector+Search',
+    );
+    expect(searchForLanguageSwitch('?search=hnsw&series=ANN')).toBe('?search=hnsw');
+    expect(searchForLanguageSwitch('')).toBe('');
+  });
+});
+
+describe('LanguageSwitcher', () => {
+  it('언어 링크에 series query를 제외한 현재 필터를 유지한다', () => {
+    navigationMocks.pathname = '/blog';
+    window.history.replaceState(null, '', '/blog/?series=ANN%20%EB%85%BC%EB%AC%B8&tags=Web');
+
+    render(<LanguageSwitcher />);
+    fireEvent.click(screen.getByRole('button', { name: 'Language switcher' }));
+
+    const englishLink = screen.getByRole('link', { name: /English/ });
+    expect(englishLink.getAttribute('href')).toBe('/en/blog?tags=Web');
+    expect(englishLink.getAttribute('href')).not.toContain('series');
+  });
+});

--- a/src/components/layout/Header/LanguageSwitcher.tsx
+++ b/src/components/layout/Header/LanguageSwitcher.tsx
@@ -60,6 +60,21 @@ export function localizedPathname(pathname: string | null | undefined, lang: Pos
 }
 
 /**
+ * 언어 전환 시 유지하면 안 되는 query를 제거합니다.
+ * series 이름은 언어별로 번역되므로(카테고리/태그와 달리) 전환 후 매칭되지 않아 필터를 해제합니다.
+ */
+export function searchForLanguageSwitch(search: string): string {
+  if (!search) {
+    return '';
+  }
+
+  const params = new URLSearchParams(search);
+  params.delete('series');
+  const queryString = params.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+/**
  * LanguageSwitcher 컴포넌트
  *
  * KR/EN/JP 콘텐츠 언어 전환 드롭다운.
@@ -105,7 +120,7 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
 
   const toggleOpen = () => {
     if (!isOpen && typeof window !== 'undefined') {
-      setSearch(window.location.search);
+      setSearch(searchForLanguageSwitch(window.location.search));
     }
     setIsOpen(prev => !prev);
   };

--- a/src/components/sections/BlogHeader/BlogHeader.test.tsx
+++ b/src/components/sections/BlogHeader/BlogHeader.test.tsx
@@ -120,16 +120,24 @@ describe('BlogHeader', () => {
       expect(screen.getByText(/Tags:/)).toBeInTheDocument();
       expect(screen.getByText('Frontend, Web')).toBeInTheDocument();
 
-      // 카테고리와 태그가 모두 선택된 경우
+      // 시리즈가 선택된 경우
+      rerender(<BlogHeader searchValue="React" selectedSeries="ANN 논문 리뷰" />);
+      expect(screen.getByText(/Series:/)).toBeInTheDocument();
+      expect(screen.getByText('ANN 논문 리뷰')).toBeInTheDocument();
+
+      // 카테고리, 시리즈, 태그가 모두 선택된 경우
       rerender(
         <BlogHeader
           searchValue="React"
           selectedCategory="JavaScript"
+          selectedSeries="ANN 논문 리뷰"
           selectedTags={['Frontend', 'Web']}
         />,
       );
       expect(screen.getByText(/Category:/)).toBeInTheDocument();
       expect(screen.getByText('JavaScript')).toBeInTheDocument();
+      expect(screen.getByText(/Series:/)).toBeInTheDocument();
+      expect(screen.getByText('ANN 논문 리뷰')).toBeInTheDocument();
       expect(screen.getByText(/Tags:/)).toBeInTheDocument();
       expect(screen.getByText('Frontend, Web')).toBeInTheDocument();
     });

--- a/src/components/sections/BlogHeader/BlogHeader.tsx
+++ b/src/components/sections/BlogHeader/BlogHeader.tsx
@@ -28,6 +28,10 @@ export interface BlogHeaderProps {
    */
   selectedCategory?: string;
   /**
+   * 선택된 시리즈
+   */
+  selectedSeries?: string;
+  /**
    * 선택된 태그 목록
    */
   selectedTags?: string[];
@@ -51,6 +55,7 @@ export const BlogHeader: React.FC<BlogHeaderProps> = ({
   onSearch,
   isSearchLoading = false,
   selectedCategory,
+  selectedSeries,
   selectedTags = [],
   className = '',
 }) => {
@@ -110,6 +115,12 @@ export const BlogHeader: React.FC<BlogHeaderProps> = ({
               <span>
                 {' '}
                 (Category: <span className="font-bold">{selectedCategory}</span>)
+              </span>
+            )}
+            {selectedSeries && (
+              <span>
+                {' '}
+                (Series: <span className="font-bold">{selectedSeries}</span>)
               </span>
             )}
             {selectedTags.length > 0 && (

--- a/src/components/sections/BlogSidebar/BlogSidebar.tsx
+++ b/src/components/sections/BlogSidebar/BlogSidebar.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
 import { CategoryList } from '@/components/ui/blog/CategoryList';
+import { SeriesList } from '@/components/ui/blog/SeriesList';
 import { TagList } from '@/components/ui/blog/TagList';
 import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang } from '@/types/blog';
+import type { SeriesSummary } from '@/utils/blog';
 
 export interface BlogSidebarProps {
   /**
@@ -18,6 +20,14 @@ export interface BlogSidebarProps {
    * 렌더링 언어 (카테고리/태그 UI 크롬 분기)
    */
   lang?: PostLang;
+  /**
+   * 표시할 시리즈 목록. 비어 있으면 시리즈 섹션을 표시하지 않습니다.
+   */
+  series?: SeriesSummary[];
+  /**
+   * 선택된 시리즈 이름
+   */
+  selectedSeries?: string;
   /**
    * 표시할 태그 목록
    */
@@ -54,6 +64,10 @@ export interface BlogSidebarProps {
    */
   onMoreCategoriesClick?: () => void;
   /**
+   * 시리즈 클릭 이벤트 핸들러 (선택된 시리즈를 다시 클릭하면 해제)
+   */
+  onSeriesClick?: (seriesName: string) => void;
+  /**
    * 태그 클릭 이벤트 핸들러
    */
   onTagClick?: (tag: string) => void;
@@ -82,6 +96,8 @@ export interface BlogSidebarProps {
 export const BlogSidebar: React.FC<BlogSidebarProps> = ({
   categories,
   selectedCategory,
+  series = [],
+  selectedSeries,
   tags,
   selectedTags = [],
   lang = DEFAULT_POST_LANG,
@@ -91,6 +107,7 @@ export const BlogSidebar: React.FC<BlogSidebarProps> = ({
   className = '',
   onCategoryClick,
   onMoreCategoriesClick,
+  onSeriesClick,
   onTagClick,
   onTagRemove,
   onMoreTagsClick,
@@ -115,6 +132,16 @@ export const BlogSidebar: React.FC<BlogSidebarProps> = ({
         onCategoryClick={onCategoryClick}
         onMoreClick={onMoreCategoriesClick}
       />
+
+      {/* 시리즈 목록 - 시리즈가 있을 때만 표시 */}
+      {series.length > 0 && (
+        <SeriesList
+          series={series}
+          selectedSeries={selectedSeries}
+          lang={lang}
+          onSeriesClick={onSeriesClick}
+        />
+      )}
 
       {/* 태그 목록 */}
       <TagList

--- a/src/components/sections/PostComments/PostComments.tsx
+++ b/src/components/sections/PostComments/PostComments.tsx
@@ -4,7 +4,18 @@ import React, { useEffect, useRef } from 'react';
 
 import { THEME_STORAGE_KEY } from '@/constants';
 import { useThemeStore } from '@/store/themeStore';
+import { DEFAULT_POST_LANG } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
 import { logError } from '@/utils/logger';
+
+/**
+ * 라우트 언어를 Giscus locale 코드로 매핑합니다. (kr 원문은 Giscus의 ko)
+ */
+const GISCUS_LANG: Record<PostLang, string> = {
+  kr: 'ko',
+  en: 'en',
+  ja: 'ja',
+};
 
 /**
  * PostComments 컴포넌트 Props 인터페이스
@@ -12,6 +23,8 @@ import { logError } from '@/utils/logger';
 export interface PostCommentsProps {
   /** 댓글을 구분하기 위한 안정적인 Giscus term. 블로그 글에서는 slug를 사용합니다. */
   term?: string;
+  /** 댓글 UI 언어. 라우트 언어(kr/en/ja)를 Giscus locale로 매핑합니다. */
+  lang?: PostLang;
   /** 추가적인 CSS 클래스명 */
   className?: string;
 }
@@ -31,7 +44,11 @@ export interface PostCommentsProps {
  * @param term - 댓글을 구분하기 위한 안정적인 Giscus term
  * @param className - 추가적인 CSS 클래스명
  */
-export function PostComments({ term, className = '' }: PostCommentsProps) {
+export function PostComments({
+  term,
+  lang = DEFAULT_POST_LANG,
+  className = '',
+}: PostCommentsProps) {
   const commentsRef = useRef<HTMLDivElement>(null);
   const isGiscusLoadedRef = useRef(false);
   const { theme } = useThemeStore();
@@ -89,7 +106,7 @@ export function PostComments({ term, className = '' }: PostCommentsProps) {
       'data-emit-metadata': '0',
       'data-input-position': 'top',
       'data-theme': initialTheme,
-      'data-lang': 'ko',
+      'data-lang': GISCUS_LANG[lang] ?? GISCUS_LANG[DEFAULT_POST_LANG],
       crossorigin: 'anonymous',
       async: 'true',
       ...(term && { 'data-term': term }),
@@ -106,7 +123,7 @@ export function PostComments({ term, className = '' }: PostCommentsProps) {
     commentsRef.current.appendChild(script);
     isGiscusLoadedRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [term]); // theme는 초기 로드 시에만 필요하므로 의존성에서 제외
+  }, [term, lang]); // theme는 초기 로드 시에만 필요하므로 의존성에서 제외
 
   // 테마 변경 시 Giscus에 메시지 전송 (스크립트 재로드 없이)
   useEffect(() => {

--- a/src/components/sections/PostSeries/PostSeries.stories.tsx
+++ b/src/components/sections/PostSeries/PostSeries.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { PostSeries } from './PostSeries';
+import type { PostSeriesPost } from './PostSeries';
+
+const samplePosts: PostSeriesPost[] = [
+  {
+    id: 1,
+    title: 'Notion CMS 블로그 만들기 1편 - 왜 Notion인가',
+    href: '/blog/notion-cms-blog-1',
+  },
+  {
+    id: 2,
+    title: 'Notion CMS 블로그 만들기 2편 - 콘텐츠 파이프라인 설계',
+    href: '/blog/notion-cms-blog-2',
+  },
+  {
+    id: 3,
+    title: 'Notion CMS 블로그 만들기 3편 - Markdown 렌더링',
+    href: '/blog/notion-cms-blog-3',
+  },
+  {
+    id: 4,
+    title: 'Notion CMS 블로그 만들기 4편 - 4개월 회고',
+    href: '/blog/notion-cms-blog-4',
+  },
+];
+
+const meta: Meta<typeof PostSeries> = {
+  title: 'Sections/PostSeries',
+  component: PostSeries,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          '포스트가 속한 시리즈(글 묶음)를 표시하는 organism 컴포넌트입니다. 시리즈 이름과 현재 위치(n / m)를 항상 보여주고, 헤더 클릭 시 시리즈 전체 목록을 펼칠 수 있습니다.',
+      },
+    },
+  },
+  argTypes: {
+    name: {
+      description: '시리즈 이름',
+      control: 'text',
+    },
+    posts: {
+      description: '시리즈에 속한 포스트 목록 (시리즈 순서대로 정렬된 상태)',
+      control: 'object',
+    },
+    currentPostId: {
+      description: '현재 읽고 있는 포스트 ID',
+      control: 'number',
+    },
+    lang: {
+      description: '렌더링 언어',
+      control: 'select',
+      options: ['kr', 'en', 'ja'],
+    },
+    defaultExpanded: {
+      description: '초기 펼침 여부',
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PostSeries>;
+
+/**
+ * 기본 상태 (접힌 상태)
+ */
+export const Default: Story = {
+  args: {
+    name: 'Notion CMS 블로그 만들기',
+    posts: samplePosts,
+    currentPostId: 2,
+  },
+};
+
+/**
+ * 펼친 상태 - 현재 글 강조와 다른 편으로의 이동 링크
+ */
+export const Expanded: Story = {
+  args: {
+    ...Default.args,
+    defaultExpanded: true,
+  },
+};
+
+/**
+ * 첫 번째 글을 읽는 중
+ */
+export const FirstPost: Story = {
+  args: {
+    ...Default.args,
+    currentPostId: 1,
+    defaultExpanded: true,
+  },
+};
+
+/**
+ * 영어 라벨
+ */
+export const English: Story = {
+  args: {
+    ...Default.args,
+    lang: 'en',
+    defaultExpanded: true,
+  },
+};
+
+/**
+ * 일본어 라벨
+ */
+export const Japanese: Story = {
+  args: {
+    ...Default.args,
+    lang: 'ja',
+    defaultExpanded: true,
+  },
+};
+
+/**
+ * 긴 시리즈 이름과 긴 포스트 제목 (truncate 확인)
+ */
+export const LongTitles: Story = {
+  args: {
+    name: '아주 길고 장황한 시리즈 이름이 들어갔을 때 말줄임이 잘 동작하는지 확인하기 위한 시리즈',
+    posts: [
+      {
+        id: 1,
+        title:
+          '아주 길고 장황한 포스트 제목이 들어갔을 때 말줄임이 잘 동작하는지 확인하기 위한 첫 번째 포스트입니다',
+        href: '/blog/long-title-1',
+      },
+      ...samplePosts.slice(1),
+    ],
+    currentPostId: 1,
+    defaultExpanded: true,
+  },
+};

--- a/src/components/sections/PostSeries/PostSeries.test.tsx
+++ b/src/components/sections/PostSeries/PostSeries.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { PostSeries } from './PostSeries';
+import type { PostSeriesPost } from './PostSeries';
+
+const samplePosts: PostSeriesPost[] = [
+  { id: 1, title: '시리즈 1편', href: '/blog/series-1' },
+  { id: 2, title: '시리즈 2편', href: '/blog/series-2' },
+  { id: 3, title: '시리즈 3편', href: '/blog/series-3' },
+];
+
+describe('PostSeries', () => {
+  it('시리즈 이름과 라벨을 표시한다', () => {
+    render(<PostSeries name="테스트 시리즈" posts={samplePosts} currentPostId={2} />);
+
+    expect(screen.getByText('시리즈')).toBeInTheDocument();
+    expect(screen.getByText('테스트 시리즈')).toBeInTheDocument();
+  });
+
+  it('현재 위치를 n / m 형태로 표시한다', () => {
+    render(<PostSeries name="테스트 시리즈" posts={samplePosts} currentPostId={2} />);
+
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+  });
+
+  it('기본 상태에서는 목록이 접혀 있다', () => {
+    render(<PostSeries name="테스트 시리즈" posts={samplePosts} currentPostId={2} />);
+
+    expect(screen.queryByText('시리즈 1편')).not.toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('헤더 클릭 시 목록이 펼쳐진다', () => {
+    render(<PostSeries name="테스트 시리즈" posts={samplePosts} currentPostId={2} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByText('시리즈 1편')).toBeInTheDocument();
+    expect(screen.getByText('시리즈 3편')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('defaultExpanded로 펼친 상태로 시작할 수 있다', () => {
+    render(
+      <PostSeries name="테스트 시리즈" posts={samplePosts} currentPostId={2} defaultExpanded />,
+    );
+
+    expect(screen.getByText('시리즈 1편')).toBeInTheDocument();
+  });
+
+  it('현재 포스트는 링크가 아닌 강조 표시로 렌더링한다', () => {
+    render(
+      <PostSeries name="테스트 시리즈" posts={samplePosts} currentPostId={2} defaultExpanded />,
+    );
+
+    expect(screen.getByText('현재')).toBeInTheDocument();
+    // 현재 글(2편)은 링크가 없어야 한다
+    expect(screen.getByText('시리즈 2편').closest('a')).toBeNull();
+    // 다른 글은 링크로 이동할 수 있어야 한다
+    expect(screen.getByText('시리즈 1편').closest('a')).toHaveAttribute('href', '/blog/series-1');
+  });
+
+  it('언어에 맞는 라벨을 표시한다', () => {
+    render(
+      <PostSeries
+        name="Test Series"
+        posts={samplePosts}
+        currentPostId={2}
+        lang="en"
+        defaultExpanded
+      />,
+    );
+
+    expect(screen.getByText('Series')).toBeInTheDocument();
+    expect(screen.getByText('Now')).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/PostSeries/PostSeries.tsx
+++ b/src/components/sections/PostSeries/PostSeries.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { Album, ChevronDown } from 'lucide-react';
+import Link from 'next/link';
+import React, { useState } from 'react';
+
+import { Heading, Text } from '@/components/ui/typography';
+import { getPostSeriesStrings } from '@/constants/i18n';
+import { DEFAULT_POST_LANG } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+
+/**
+ * 시리즈 목록에 표시되는 개별 포스트
+ */
+export interface PostSeriesPost {
+  /**
+   * 포스트 고유 ID
+   */
+  id: number;
+  /**
+   * 포스트 제목
+   */
+  title: string;
+  /**
+   * 포스트 링크 URL
+   */
+  href: string;
+}
+
+export interface PostSeriesProps {
+  /**
+   * 시리즈 이름
+   */
+  name: string;
+  /**
+   * 시리즈에 속한 포스트 목록 (시리즈 내 순서대로 정렬된 상태)
+   */
+  posts: PostSeriesPost[];
+  /**
+   * 현재 읽고 있는 포스트 ID
+   */
+  currentPostId: number;
+  /**
+   * 렌더링 언어 (라벨 문구에 사용)
+   */
+  lang?: PostLang;
+  /**
+   * 초기 펼침 여부
+   * @default false
+   */
+  defaultExpanded?: boolean;
+  /**
+   * 추가 CSS 클래스
+   */
+  className?: string;
+}
+
+/**
+ * PostSeries 컴포넌트
+ * 포스트가 속한 시리즈(글 묶음)를 표시하는 organism 컴포넌트.
+ * 시리즈 이름과 현재 위치(n / m)를 항상 보여주고,
+ * 헤더를 클릭하면 시리즈 전체 목록을 펼쳐 다른 편으로 이동할 수 있습니다.
+ */
+export const PostSeries = ({
+  name,
+  posts,
+  currentPostId,
+  lang = DEFAULT_POST_LANG,
+  defaultExpanded = false,
+  className = '',
+}: PostSeriesProps) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const strings = getPostSeriesStrings(lang);
+
+  const currentIndex = posts.findIndex(post => post.id === currentPostId);
+  const currentPosition = currentIndex >= 0 ? currentIndex + 1 : undefined;
+
+  return (
+    <section
+      className={`rounded-xl bg-[color:var(--color-primary)] text-[color:var(--color-text)] ${className}`}
+    >
+      {/* 헤더 - 클릭 시 시리즈 목록 펼침/접힘 */}
+      <button
+        type="button"
+        onClick={() => {
+          setIsExpanded(prev => !prev);
+        }}
+        aria-expanded={isExpanded}
+        aria-label={isExpanded ? strings.collapseSeries : strings.expandSeries}
+        className="flex w-full cursor-pointer items-center justify-between gap-4 p-5 text-left"
+      >
+        <div className="min-w-0">
+          {/* eyebrow 라벨 */}
+          <span className="mb-1.5 flex items-center gap-1.5 text-xs tracking-wide opacity-60">
+            <Album aria-hidden="true" className="h-3.5 w-3.5" />
+            {strings.seriesLabel}
+          </span>
+          {/* 시리즈 이름 - 날짜/읽기 시간과 같은 세리프 악센트 */}
+          <Heading level={4} fontFamily="maruBuri" className="truncate">
+            {name}
+          </Heading>
+        </div>
+
+        <span className="flex flex-shrink-0 items-center gap-3">
+          {/* 현재 위치 n / m */}
+          <span className="font-maruBuri text-sm opacity-70">
+            {currentPosition !== undefined ? `${currentPosition} / ${posts.length}` : posts.length}
+          </span>
+          <ChevronDown
+            aria-hidden="true"
+            className={`size-5 opacity-70 transition-transform duration-200 ${
+              isExpanded ? 'rotate-180' : ''
+            }`}
+          />
+        </span>
+      </button>
+
+      {/* 시리즈 포스트 목록 */}
+      {isExpanded && (
+        <ol className="space-y-1 px-3 pb-4">
+          {posts.map((post, index) => {
+            const isCurrent = post.id === currentPostId;
+            const rowStyles =
+              'flex items-center gap-3 rounded-md px-3 py-2.5 transition-all duration-200';
+            const rowContent = (
+              <>
+                <span
+                  className={`w-5 flex-shrink-0 text-right font-maruBuri text-sm ${
+                    isCurrent ? 'opacity-90' : 'opacity-50'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {index + 1}
+                </span>
+                <Text className={`min-w-0 flex-1 truncate text-sm ${isCurrent ? 'font-bold' : ''}`}>
+                  {post.title}
+                </Text>
+                {isCurrent && (
+                  <span className="flex-shrink-0 rounded-sm bg-[color:var(--color-text)] px-2 py-0.5 text-xs text-[color:var(--color-background)]">
+                    {strings.currentPost}
+                  </span>
+                )}
+              </>
+            );
+
+            return (
+              <li key={post.id}>
+                {isCurrent ? (
+                  <div
+                    className={`${rowStyles} bg-[color:var(--color-background)] shadow-sm`}
+                    aria-current="true"
+                  >
+                    {rowContent}
+                  </div>
+                ) : (
+                  <Link
+                    href={post.href}
+                    className={`${rowStyles} cursor-pointer hover:bg-[color:var(--color-secondary)] hover:shadow-sm`}
+                  >
+                    {rowContent}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </section>
+  );
+};
+
+export default PostSeries;

--- a/src/components/sections/PostSeries/index.tsx
+++ b/src/components/sections/PostSeries/index.tsx
@@ -1,0 +1,1 @@
+export { PostSeries, type PostSeriesProps, type PostSeriesPost } from './PostSeries';

--- a/src/components/templates/PostTemplate/PostTemplate.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.tsx
@@ -127,8 +127,9 @@ export const PostTemplate = ({
   tableOfContents = [],
 }: PostTemplateProps) => {
   // 기본 컨테이너 스타일 - xl 이상에서는 1024px (PostBody 768px + ToC 256px), 이하에서는 768px
+  // xl에서는 좌우 패딩을 제거해 768 + 256 = 1024가 정확히 맞도록 한다
   const containerStyles = `
-    min-h-screen w-full mx-auto my-20 px-3
+    min-h-screen w-full mx-auto my-20 px-3 xl:px-0
     max-w-[768px] xl:max-w-[1024px]
   `;
 

--- a/src/components/templates/PostTemplate/PostTemplate.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { PostComments } from '@/components/sections/PostComments';
 import { PostNavigator } from '@/components/sections/PostNavigator';
+import { PostSeries, type PostSeriesPost } from '@/components/sections/PostSeries';
 import { RelatedPosts, type RelatedPostsProps } from '@/components/sections/RelatedPosts';
 import { PostBody } from '@/components/ui/blog/PostBody';
 import { PostHeader } from '@/components/ui/blog/PostHeader';
@@ -56,6 +57,11 @@ export interface PostTemplateProps {
    */
   onTagClick?: (tag: string) => void;
   /**
+   * 현재 포스트가 속한 시리즈의 포스트 목록 (시리즈 순서대로 정렬된 상태).
+   * post.series가 있고 목록이 2개 이상일 때만 시리즈 박스를 표시합니다.
+   */
+  seriesPosts?: PostSeriesPost[];
+  /**
    * 관련 포스트 목록
    */
   relatedPosts?: RelatedPostsProps['posts'];
@@ -108,6 +114,7 @@ export const PostTemplate = ({
   lang = DEFAULT_POST_LANG,
   prevPost,
   nextPost,
+  seriesPosts = [],
   onCategoryClick,
   onTagClick,
   relatedPosts = [],
@@ -137,6 +144,18 @@ export const PostTemplate = ({
         {lang !== DEFAULT_POST_LANG && (
           <section className="mb-6 max-w-[768px]">
             <TranslationNotice lang={lang} originalHref={createBlogPostHref(post)} />
+          </section>
+        )}
+
+        {/* 시리즈 박스 - 시리즈에 속한 포스트가 2개 이상일 때만 표시 */}
+        {post.series && seriesPosts.length > 1 && (
+          <section className="mb-6 max-w-[768px]">
+            <PostSeries
+              name={post.series.name}
+              posts={seriesPosts}
+              currentPostId={post.id}
+              lang={lang}
+            />
           </section>
         )}
 
@@ -189,7 +208,7 @@ export const PostTemplate = ({
 
         {/* Comments Section - 768px 유지 */}
         <section className="mb-12 max-w-[768px]">
-          <PostComments term={post.slug} />
+          <PostComments term={post.slug} lang={lang} />
         </section>
       </main>
     </div>

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -52,9 +52,9 @@ export const PostCard = ({
   // 카드 내용 컴포넌트
   const CardContent = (
     <>
-      {/* 커버 이미지 */}
+      {/* 커버 이미지 - 카드 폭에 따라 높이가 1.91:1(OG 표준)을 따라감 */}
       {cover && (
-        <div className="h-[12.5rem] relative">
+        <div className="relative aspect-[1.91/1]">
           {/* 커버 이미지가 있을 때 라벨을 이미지 위에 위치 */}
           {category && (
             <div className="absolute top-3 left-3 z-10">

--- a/src/components/ui/blog/PostCard/PostCard.tsx
+++ b/src/components/ui/blog/PostCard/PostCard.tsx
@@ -1,4 +1,4 @@
-import { Clock } from 'lucide-react';
+import { Album, Clock } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -34,6 +34,7 @@ export const PostCard = ({
   createdAt,
   readingTime,
   category,
+  series,
   tags,
   cover,
   className = '',
@@ -96,14 +97,25 @@ export const PostCard = ({
           </Heading>
         </div>
 
-        {/* 날짜 · 읽기 시간 */}
-        <div className="mb-3 flex items-center gap-2 text-left">
-          <Text fontFamily="maruBuri">{createdAt}</Text>
+        {/* 날짜 · 읽기 시간 · 시리즈 - 좁은 카드에서 날짜/시간은 줄바꿈 없이 유지하고 시리즈만 말줄임 */}
+        <div className="mb-3 flex min-w-0 items-center gap-2 text-left">
+          <Text fontFamily="maruBuri" className="flex-shrink-0 whitespace-nowrap">
+            {createdAt}
+          </Text>
           {readingTime ? (
-            <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text)]">
+            <span className="flex flex-shrink-0 items-center gap-1 whitespace-nowrap font-maruBuri text-[color:var(--color-text)]">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
               {formatReadingTime(readingTime)}
+            </span>
+          ) : null}
+          {series ? (
+            <span className="flex min-w-0 items-center gap-1 font-maruBuri text-[color:var(--color-text)]">
+              <span aria-hidden="true" className="flex-shrink-0">
+                ·
+              </span>
+              <Album aria-hidden="true" className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="min-w-0 truncate">{series.name}</span>
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -47,7 +47,7 @@ export const PostHeader = ({
   return (
     <article className={className}>
       {/* 커버 이미지 - 모든 포스트가 동일한 1.91:1(OG 표준) 박스를 쓰고,
-          원본은 자르지 않고 박스에 맞춰 늘려 채운다 (768px 기준 높이 ~402px) */}
+          원본은 자르지 않고 박스에 맞춰 늘려 채운다 */}
       {cover && (
         <div className="relative w-full aspect-[1.91/1] mb-6 rounded-xl overflow-hidden bg-[color:var(--color-primary)]">
           <Image

--- a/src/components/ui/blog/PostHeader/PostHeader.tsx
+++ b/src/components/ui/blog/PostHeader/PostHeader.tsx
@@ -46,9 +46,10 @@ export const PostHeader = ({
 }: PostHeaderProps) => {
   return (
     <article className={className}>
-      {/* 커버 이미지 */}
+      {/* 커버 이미지 - 모든 포스트가 동일한 1.91:1(OG 표준) 박스를 쓰고,
+          원본은 자르지 않고 박스에 맞춰 늘려 채운다 (768px 기준 높이 ~402px) */}
       {cover && (
-        <div className="relative w-full h-[18.75rem] md:h-[25rem] mb-6 rounded-xl overflow-hidden bg-[color:var(--color-primary)]">
+        <div className="relative w-full aspect-[1.91/1] mb-6 rounded-xl overflow-hidden bg-[color:var(--color-primary)]">
           <Image
             src={cover}
             alt={title}

--- a/src/components/ui/blog/PostRow/PostRow.tsx
+++ b/src/components/ui/blog/PostRow/PostRow.tsx
@@ -1,4 +1,4 @@
-import { Clock } from 'lucide-react';
+import { Album, Clock } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -41,6 +41,7 @@ export const PostRow = ({
   createdAt,
   readingTime,
   category,
+  series,
   tags,
   cover,
   className = '',
@@ -79,14 +80,25 @@ export const PostRow = ({
           {title}
         </Heading>
 
-        {/* 날짜 · 읽기 시간 */}
-        <div className="flex items-center gap-2">
-          <Text fontFamily="maruBuri">{createdAt}</Text>
+        {/* 날짜 · 읽기 시간 · 시리즈 - 좁은 화면에서 날짜/시간은 줄바꿈 없이 유지하고 시리즈만 말줄임 */}
+        <div className="flex min-w-0 items-center gap-2">
+          <Text fontFamily="maruBuri" className="flex-shrink-0 whitespace-nowrap">
+            {createdAt}
+          </Text>
           {readingTime ? (
-            <span className="flex items-center gap-1 font-maruBuri text-[color:var(--color-text)]">
+            <span className="flex flex-shrink-0 items-center gap-1 whitespace-nowrap font-maruBuri text-[color:var(--color-text)]">
               <span aria-hidden="true">·</span>
               <Clock aria-hidden="true" className="h-3.5 w-3.5" />
               {formatReadingTime(readingTime)}
+            </span>
+          ) : null}
+          {series ? (
+            <span className="flex min-w-0 items-center gap-1 font-maruBuri text-[color:var(--color-text)]">
+              <span aria-hidden="true" className="flex-shrink-0">
+                ·
+              </span>
+              <Album aria-hidden="true" className="h-3.5 w-3.5 flex-shrink-0" />
+              <span className="min-w-0 truncate">{series.name}</span>
             </span>
           ) : null}
         </div>

--- a/src/components/ui/blog/SeriesList/SeriesList.stories.tsx
+++ b/src/components/ui/blog/SeriesList/SeriesList.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SeriesList } from './SeriesList';
+
+const sampleSeries = [
+  { name: 'Notion CMS 블로그 만들기', count: 4 },
+  { name: 'Vector Search 파헤치기', count: 3 },
+  { name: 'Next.js 정적 블로그 운영기', count: 2 },
+];
+
+const meta: Meta<typeof SeriesList> = {
+  title: 'UI/Blog/SeriesList',
+  component: SeriesList,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          '블로그 사이드바에서 시리즈(글 묶음) 목록을 표시하는 분자 컴포넌트입니다. 시리즈 이름과 포스트 개수를 보여주고, 선택된 시리즈를 다시 클릭하면 해제됩니다.',
+      },
+    },
+  },
+  argTypes: {
+    series: {
+      description: '표시할 시리즈 목록 (이름과 포스트 개수)',
+      control: 'object',
+    },
+    selectedSeries: {
+      description: '선택된 시리즈 이름',
+      control: 'text',
+    },
+    lang: {
+      description: '렌더링 언어',
+      control: 'select',
+      options: ['kr', 'en', 'ja'],
+    },
+    showMore: {
+      description: '더보기 표시 여부',
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SeriesList>;
+
+/**
+ * 기본 상태
+ */
+export const Default: Story = {
+  args: {
+    series: sampleSeries,
+  },
+};
+
+/**
+ * 시리즈가 선택된 상태
+ */
+export const Selected: Story = {
+  args: {
+    series: sampleSeries,
+    selectedSeries: 'Vector Search 파헤치기',
+  },
+};
+
+/**
+ * 영어 라벨
+ */
+export const English: Story = {
+  args: {
+    series: sampleSeries,
+    lang: 'en',
+  },
+};
+
+/**
+ * 더보기 버튼 표시 (초기 표시 개수 초과)
+ */
+export const WithLoadMore: Story = {
+  args: {
+    series: [
+      ...sampleSeries,
+      { name: 'Kubernetes 삽질기', count: 5 },
+      { name: 'Rust로 CLI 만들기', count: 2 },
+      { name: 'LLM 블로그 자동화', count: 6 },
+    ],
+    initialDisplayCount: 5,
+  },
+};

--- a/src/components/ui/blog/SeriesList/SeriesList.test.tsx
+++ b/src/components/ui/blog/SeriesList/SeriesList.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { SeriesList } from './SeriesList';
+
+const sampleSeries = [
+  { name: 'A 시리즈', count: 4 },
+  { name: 'B 시리즈', count: 2 },
+];
+
+describe('SeriesList', () => {
+  it('시리즈 제목과 목록을 렌더링한다', () => {
+    render(<SeriesList series={sampleSeries} />);
+
+    expect(screen.getByText('시리즈')).toBeInTheDocument();
+    expect(screen.getByText('A 시리즈')).toBeInTheDocument();
+    expect(screen.getByText('B 시리즈')).toBeInTheDocument();
+  });
+
+  it('시리즈별 포스트 개수를 표시한다', () => {
+    render(<SeriesList series={sampleSeries} />);
+
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('시리즈가 없으면 아무것도 렌더링하지 않는다', () => {
+    const { container } = render(<SeriesList series={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('시리즈 클릭 시 핸들러를 호출한다', () => {
+    const onSeriesClick = vi.fn();
+    render(<SeriesList series={sampleSeries} onSeriesClick={onSeriesClick} />);
+
+    fireEvent.click(screen.getByText('A 시리즈'));
+
+    expect(onSeriesClick).toHaveBeenCalledWith('A 시리즈');
+  });
+
+  it('선택된 시리즈에 aria-pressed를 표시하고 다시 클릭할 수 있다', () => {
+    const onSeriesClick = vi.fn();
+    render(
+      <SeriesList series={sampleSeries} selectedSeries="A 시리즈" onSeriesClick={onSeriesClick} />,
+    );
+
+    const selectedButton = screen.getByText('A 시리즈').closest('button');
+    expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
+
+    // 선택 해제를 위해 다시 클릭할 수 있어야 한다
+    fireEvent.click(selectedButton!);
+    expect(onSeriesClick).toHaveBeenCalledWith('A 시리즈');
+  });
+
+  it('언어에 맞는 섹션 제목을 표시한다', () => {
+    render(<SeriesList series={sampleSeries} lang="en" />);
+
+    expect(screen.getByText('Series')).toBeInTheDocument();
+  });
+
+  it('초기 표시 개수를 초과하면 더보기 버튼으로 추가 노출한다', () => {
+    const manySeries = Array.from({ length: 7 }, (_, i) => ({
+      name: `시리즈 ${i + 1}`,
+      count: i + 1,
+    }));
+    render(<SeriesList series={manySeries} initialDisplayCount={5} loadMoreCount={5} />);
+
+    expect(screen.queryByText('시리즈 6')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('+ More'));
+
+    expect(screen.getByText('시리즈 6')).toBeInTheDocument();
+    expect(screen.getByText('시리즈 7')).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/blog/SeriesList/SeriesList.tsx
+++ b/src/components/ui/blog/SeriesList/SeriesList.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { LoadMoreButton } from '@/components/ui/buttons/LoadMoreButton';
+import { Heading } from '@/components/ui/typography';
+import { getBlogUiStrings } from '@/constants/i18n';
+import { DEFAULT_POST_LANG } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
+import type { SeriesSummary } from '@/utils/blog';
+
+export interface SeriesListProps {
+  /**
+   * 표시할 시리즈 목록 (이름과 포스트 개수)
+   */
+  series: SeriesSummary[];
+  /**
+   * 선택된 시리즈 이름
+   */
+  selectedSeries?: string;
+  /**
+   * 렌더링 언어 (섹션 제목 분기)
+   */
+  lang?: PostLang;
+  /**
+   * 더보기 표시 여부
+   * @default true
+   */
+  showMore?: boolean;
+  /**
+   * 초기에 보여줄 시리즈 개수
+   * @default 5
+   */
+  initialDisplayCount?: number;
+  /**
+   * 더보기 클릭 시 추가로 보여줄 시리즈 개수
+   * @default 5
+   */
+  loadMoreCount?: number;
+  /**
+   * 추가 클래스명
+   */
+  className?: string;
+  /**
+   * 시리즈 클릭 이벤트 핸들러 (선택된 시리즈를 다시 클릭하면 해제)
+   */
+  onSeriesClick?: (seriesName: string) => void;
+}
+
+/**
+ * SeriesList 컴포넌트
+ * 블로그 사이드바에서 시리즈(글 묶음) 목록을 표시하는 분자 컴포넌트.
+ * CategoryList vertical 레이아웃과 같은 톤으로, 시리즈 이름과 포스트 개수를 보여줍니다.
+ * 카테고리와 달리 "전체" 항목이 없으므로 선택된 시리즈를 다시 클릭해 해제할 수 있습니다.
+ */
+export const SeriesList = ({
+  series,
+  selectedSeries,
+  lang = DEFAULT_POST_LANG,
+  showMore = true,
+  initialDisplayCount = 5,
+  loadMoreCount = 5,
+  className = '',
+  onSeriesClick,
+}: SeriesListProps) => {
+  const strings = getBlogUiStrings(lang);
+  const [displayCount, setDisplayCount] = useState(initialDisplayCount);
+
+  // 표시할 시리즈가 없으면 섹션 자체를 렌더링하지 않는다
+  if (series.length === 0) {
+    return null;
+  }
+
+  // CategoryList vertical과 동일한 컨테이너/구분선 스타일
+  const containerStyles = 'w-full max-w-[48rem] lg:w-[15.375rem] lg:max-w-none p-3 rounded-lg';
+  const dividerStyles = 'border-[color:var(--color-text)] opacity-15';
+
+  const displayedSeries = series.slice(0, displayCount);
+  const shouldShowMoreButton = showMore && series.length > displayCount;
+
+  return (
+    <div className={`${containerStyles} ${className}`}>
+      {/* 상단 헤더 - 제목 */}
+      <div className="flex justify-between items-center mb-4">
+        <Heading level={3} fontFamily="maruBuri" className="my-1 text-2xl md:text-xl font-bold">
+          {strings.seriesHeading}
+        </Heading>
+      </div>
+
+      {/* 구분선 - 헤더 바로 아래 표시 */}
+      <hr className={`border-t-[0.03125rem] ${dividerStyles} mb-5 mt-0`} />
+
+      {/* 시리즈 목록 */}
+      <div className="flex flex-col space-y-1 mb-3">
+        {displayedSeries.map(item => {
+          const isSelected = selectedSeries === item.name;
+
+          return (
+            <button
+              key={item.name}
+              type="button"
+              onClick={() => onSeriesClick?.(item.name)}
+              aria-pressed={isSelected}
+              className={`
+                transition-all duration-200 flex items-center justify-between gap-2
+                focus:outline-none focus-visible:outline-none
+                px-2.5 py-1.5 text-left text-sm rounded w-full cursor-pointer
+                text-[color:var(--color-text)]
+                ${
+                  isSelected
+                    ? 'bg-[color:var(--color-primary)] font-bold'
+                    : 'bg-transparent font-normal hover:bg-[color:var(--color-primary)] hover:bg-opacity-50'
+                }
+              `}
+            >
+              <span className="min-w-0 truncate">{item.name}</span>
+              <span className="flex-shrink-0 font-maruBuri text-xs opacity-60">{item.count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 더보기 링크 - 전체 시리즈가 현재 표시 개수보다 많을 때만 표시 */}
+      {shouldShowMoreButton && (
+        <LoadMoreButton
+          text={strings.loadMore}
+          className="font-maruBuri"
+          onClick={() => {
+            setDisplayCount(displayCount + loadMoreCount);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default SeriesList;

--- a/src/components/ui/blog/SeriesList/index.tsx
+++ b/src/components/ui/blog/SeriesList/index.tsx
@@ -1,0 +1,1 @@
+export { SeriesList, type SeriesListProps } from './SeriesList';

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -4,6 +4,7 @@
  * 선택된 라우트 언어(kr/en/ja)에 맞춰 분기하는 문구는 다음으로 한정합니다.
  * - 헤더 네비게이션(About/Blog)
  * - 카테고리 제목(Category) / "전체"(All) 라벨
+ * - 시리즈 제목(Series) / 포스트 상세 시리즈 박스 라벨
  * - 태그 제목(Tags)
  * - 정렬 라벨(Sort)
  * 그 외 보조 문구(더보기/모두 지우기/정렬 aria 등)와 "둘러보기" 버튼은 항상 영어로 표시합니다.
@@ -20,6 +21,8 @@ export interface BlogUiStrings {
   categoryHeading: string;
   /** "전체" 카테고리 표시 라벨 */
   allCategory: string;
+  /** 시리즈 섹션 제목 */
+  seriesHeading: string;
   /** 태그 섹션 제목 */
   tagHeading: string;
   /** 표시할 태그가 없을 때 문구 */
@@ -37,12 +40,20 @@ export interface BlogUiStrings {
 }
 
 /** 언어별로 분기하는 라벨(카테고리/태그/정렬 제목). */
-type LocalizedBlogUiStrings = Pick<BlogUiStrings, 'categoryHeading' | 'tagHeading' | 'sort'>;
+type LocalizedBlogUiStrings = Pick<
+  BlogUiStrings,
+  'categoryHeading' | 'seriesHeading' | 'tagHeading' | 'sort'
+>;
 
 const LOCALIZED_BLOG_UI_STRINGS: Record<PostLang, LocalizedBlogUiStrings> = {
-  kr: { categoryHeading: '카테고리', tagHeading: '태그', sort: '정렬' },
-  en: { categoryHeading: 'Category', tagHeading: 'Tags', sort: 'Sort' },
-  ja: { categoryHeading: 'カテゴリー', tagHeading: 'タグ', sort: '並び替え' },
+  kr: { categoryHeading: '카테고리', seriesHeading: '시리즈', tagHeading: '태그', sort: '정렬' },
+  en: { categoryHeading: 'Category', seriesHeading: 'Series', tagHeading: 'Tags', sort: 'Sort' },
+  ja: {
+    categoryHeading: 'カテゴリー',
+    seriesHeading: 'シリーズ',
+    tagHeading: 'タグ',
+    sort: '並び替え',
+  },
 };
 
 /**
@@ -75,6 +86,41 @@ export function getBlogUiStrings(lang: PostLang = DEFAULT_POST_LANG): BlogUiStri
 export function getExplorePostsLabel(selectedCategory?: string): string {
   const isAll = !selectedCategory || selectedCategory === ALL_POSTS_CATEGORY;
   return isAll ? 'Browse all posts' : `Browse ${selectedCategory} posts`;
+}
+
+/**
+ * 포스트 상세의 시리즈 박스 라벨(언어별).
+ * eyebrow(시리즈)와 현재 글 배지만 언어를 따르고, 접기/펼치기 aria는 영어로 고정합니다.
+ */
+export interface PostSeriesStrings {
+  /** 시리즈 섹션 eyebrow 라벨 */
+  seriesLabel: string;
+  /** 시리즈 목록에서 현재 글 배지 */
+  currentPost: string;
+  /** 시리즈 목록 펼치기 aria-label (영어 고정) */
+  expandSeries: string;
+  /** 시리즈 목록 접기 aria-label (영어 고정) */
+  collapseSeries: string;
+}
+
+const LOCALIZED_POST_SERIES_STRINGS: Record<
+  PostLang,
+  Pick<PostSeriesStrings, 'seriesLabel' | 'currentPost'>
+> = {
+  kr: { seriesLabel: '시리즈', currentPost: '현재' },
+  en: { seriesLabel: 'Series', currentPost: 'Now' },
+  ja: { seriesLabel: 'シリーズ', currentPost: '現在' },
+};
+
+/**
+ * 현재 언어에 맞는 시리즈 박스 라벨을 반환합니다.
+ */
+export function getPostSeriesStrings(lang: PostLang = DEFAULT_POST_LANG): PostSeriesStrings {
+  return {
+    expandSeries: 'Show series posts',
+    collapseSeries: 'Hide series posts',
+    ...(LOCALIZED_POST_SERIES_STRINGS[lang] ?? LOCALIZED_POST_SERIES_STRINGS[DEFAULT_POST_LANG]),
+  };
 }
 
 /**

--- a/src/libs/blogPages/listPage.tsx
+++ b/src/libs/blogPages/listPage.tsx
@@ -12,6 +12,7 @@ import {
   blogLangPathPrefix,
   getPostCategories,
   getPostLanguages,
+  getPostSeriesList,
   getPostTags,
   localizePostMeta,
 } from '@/utils/blog';
@@ -100,12 +101,14 @@ export async function LocalizedBlogListPage({ lang }: { lang: PostLang }) {
 
   const posts = localizePostsForLang(result, lang);
   const categories = getPostCategories(posts);
+  const series = getPostSeriesList(posts);
   const tags = getPostTags(posts);
 
   return (
     <BlogPageClient
       initialPosts={posts}
       initialCategories={categories}
+      initialSeries={series}
       initialTags={tags}
       lang={lang}
     />

--- a/src/libs/blogPages/postPage.tsx
+++ b/src/libs/blogPages/postPage.tsx
@@ -24,6 +24,7 @@ import {
   createBlogPostHref,
   findPostByEncodedSlug,
   getPostLanguages,
+  getSeriesPosts,
   localizePostMeta,
 } from '@/utils/blog';
 import { getSiteConfig } from '@/utils/config';
@@ -167,10 +168,23 @@ export async function LocalizedPostPage({ slug, lang }: { slug: string; lang: Po
   });
   const tableOfContents = extractTableOfContentsFromMarkdown(markdown);
 
+  // 같은 시리즈의 포스트 목록 (시리즈 순서대로)
+  const seriesMetas = post.series ? getSeriesPosts(posts, post.series.name) : [];
+  const seriesPosts = seriesMetas.map((p: PostMeta) => ({
+    id: p.id,
+    title: localizePostMeta(p, lang).title,
+    href: createBlogPostHref(p, lang),
+  }));
+
   // 이전글/다음글 찾기 (같은 언어로 제공되는 포스트 기준)
-  const currentIndex = posts.findIndex((p: PostMeta) => p.id === post.id);
-  const prevPost = currentIndex > 0 ? posts[currentIndex - 1] : undefined;
-  const nextPost = currentIndex < posts.length - 1 ? posts[currentIndex + 1] : undefined;
+  // 시리즈에 속한 포스트는 시리즈 순서를 우선하고, 그 외에는 전체 목록 순서를 따릅니다.
+  const navPosts = seriesMetas.length > 1 ? seriesMetas : posts;
+  const currentIndex = navPosts.findIndex((p: PostMeta) => p.id === post.id);
+  const prevPost = currentIndex > 0 ? navPosts[currentIndex - 1] : undefined;
+  const nextPost =
+    currentIndex >= 0 && currentIndex < navPosts.length - 1
+      ? navPosts[currentIndex + 1]
+      : undefined;
 
   // 관련 포스트 찾기 (같은 카테고리의 다른 포스트들)
   const relatedPosts = posts
@@ -216,6 +230,7 @@ export async function LocalizedPostPage({ slug, lang }: { slug: string; lang: Po
               }
             : undefined
         }
+        seriesPosts={seriesPosts}
         relatedPosts={relatedPosts}
         showRelatedPosts={relatedPosts.length > 0}
         enableRelatedPostsPagination={enablePagination}

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -48,6 +48,96 @@ export interface ExportedPost {
 
 interface CopyAssetOptions {
   stretchSvg?: boolean;
+  /**
+   * 이미지 용도. body는 본문 컬럼(720px)의 레티나 2배 폭으로 webp 변환하고,
+   * cover는 OG 크롤러 호환을 위해 원본 포맷을 유지한 채 폭만 제한합니다.
+   */
+  assetKind?: 'body' | 'cover';
+}
+
+/**
+ * 빌드 시 축소·변환 대상 래스터 포맷. GIF(애니메이션)와 SVG는 원본 그대로 복사합니다.
+ */
+const RASTER_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
+/**
+ * 본문 이미지 최대 폭. 본문 컬럼(720px 표시 폭)의 레티나 2배입니다.
+ */
+const BODY_IMAGE_MAX_WIDTH = 1440;
+
+/**
+ * 커버 이미지 최대 폭. 헤더 커버 컨테이너(768px 표시 폭)의 레티나 2배입니다.
+ */
+const COVER_IMAGE_MAX_WIDTH = 1536;
+
+const WEBP_QUALITY = 82;
+
+interface PendingImageExport {
+  sourcePath: string;
+  destinationPath: string;
+  assetKind: 'body' | 'cover';
+  extension: string;
+}
+
+const pendingImageExports = new Map<string, PendingImageExport>();
+
+function isRasterImage(extension: string): boolean {
+  return RASTER_IMAGE_EXTENSIONS.has(extension);
+}
+
+async function runImageExport(job: PendingImageExport): Promise<void> {
+  // sharp는 빌드/테스트에서만 필요한 native 모듈이라 실행 시점에 lazy import합니다.
+  const { default: sharp } = await import('sharp');
+  const maxWidth = job.assetKind === 'cover' ? COVER_IMAGE_MAX_WIDTH : BODY_IMAGE_MAX_WIDTH;
+  const pipeline = sharp(job.sourcePath).rotate().resize({
+    width: maxWidth,
+    withoutEnlargement: true,
+  });
+
+  try {
+    if (job.assetKind === 'cover') {
+      // 커버는 OG 크롤러 호환을 위해 원본 포맷을 유지합니다.
+      if (job.extension === '.png') {
+        await pipeline.png().toFile(job.destinationPath);
+      } else if (job.extension === '.webp') {
+        await pipeline.webp({ quality: WEBP_QUALITY }).toFile(job.destinationPath);
+      } else {
+        await pipeline.jpeg({ quality: WEBP_QUALITY, mozjpeg: true }).toFile(job.destinationPath);
+      }
+    } else {
+      await pipeline.webp({ quality: WEBP_QUALITY }).toFile(job.destinationPath);
+    }
+  } catch (error) {
+    throw new Error(
+      `Image export failed for ${path.basename(job.sourcePath)}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+/**
+ * copyAsset이 큐에 쌓은 래스터 이미지 축소·변환 작업을 실행합니다.
+ * export 루프(exportPublishedPost 반복) 이후 반드시 한 번 await해야 하며,
+ * 대상 파일이 이미 존재하면(동일 content hash) 건너뜁니다.
+ */
+export async function flushPendingImageExports(): Promise<number> {
+  const jobs = Array.from(pendingImageExports.values());
+  pendingImageExports.clear();
+
+  const results = await Promise.all(
+    jobs.map(async job => {
+      if (fs.existsSync(job.destinationPath)) {
+        return 0;
+      }
+
+      await runImageExport(job);
+      return 1;
+    }),
+  );
+
+  return results.reduce<number>((sum, value) => sum + value, 0);
 }
 
 function isExternalUrl(value: string): boolean {
@@ -144,10 +234,35 @@ function copyAsset(
   );
   ensureDirectory(publicAssetDir);
 
-  const file = readAssetForExport(sourcePath, options);
-  const fileName = createContentHashedFileName(sourcePath, file);
-  const destinationPath = path.join(publicAssetDir, fileName);
-  fs.writeFileSync(destinationPath, file);
+  const extension = path.extname(sourcePath).toLowerCase();
+  let fileName: string;
+
+  if (isRasterImage(extension)) {
+    // 래스터 이미지는 폭 제한 축소(+본문은 webp 변환) 대상입니다. 이름의 content hash는
+    // 원본 바이트와 변환 파라미터에서 계산하므로, 원본 교체나 파라미터 변경 시 캐시가 무효화됩니다.
+    const assetKind = options.assetKind ?? 'body';
+    const file = fs.readFileSync(sourcePath);
+    const params =
+      assetKind === 'cover'
+        ? `cover-w${COVER_IMAGE_MAX_WIDTH}-q${WEBP_QUALITY}`
+        : `body-w${BODY_IMAGE_MAX_WIDTH}-q${WEBP_QUALITY}-webp`;
+    const hash = crypto.createHash('sha256').update(file).update(params).digest('hex').slice(0, 12);
+    const outputExtension = assetKind === 'cover' ? extension : '.webp';
+    fileName = `${path.parse(sourcePath).name}.${hash}${outputExtension}`;
+    const destinationPath = path.join(publicAssetDir, fileName);
+
+    pendingImageExports.set(destinationPath, {
+      sourcePath,
+      destinationPath,
+      assetKind,
+      extension,
+    });
+  } else {
+    const file = readAssetForExport(sourcePath, options);
+    fileName = createContentHashedFileName(sourcePath, file);
+    const destinationPath = path.join(publicAssetDir, fileName);
+    fs.writeFileSync(destinationPath, file);
+  }
 
   return `/${paths.publicAssetsBasePath}/${note.slug}/assets/${fileName}`.replace(/\/+/g, '/');
 }
@@ -412,7 +527,7 @@ export function transformMarkdownForExport(
 
   if (cover && isLocalAssetUrl(cover)) {
     try {
-      cover = copyAsset(note, cover, paths, { stretchSvg: true });
+      cover = copyAsset(note, cover, paths, { stretchSvg: true, assetKind: 'cover' });
     } catch (error) {
       diagnostics.push({
         level: 'error',

--- a/src/libs/content/frontmatter.ts
+++ b/src/libs/content/frontmatter.ts
@@ -84,6 +84,26 @@ function normalizeReadingTime(value: unknown): number | undefined {
 }
 
 /**
+ * series_order를 1 이상의 양의 정수로 정규화합니다.
+ * 숫자와 숫자 문자열을 허용하고, 0 이하/비정상 값은 undefined입니다.
+ */
+function normalizeSeriesOrder(value: unknown): number | undefined {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number.parseFloat(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+
+  const order = Math.round(parsed);
+  return order > 0 ? order : undefined;
+}
+
+/**
  * frontmatter lang 값을 kr/en/ja로 정규화합니다.
  * lang이 없으면 kr(원문)이고, 알 수 없는 값이면 undefined를 반환합니다.
  * KB 원본이 일본어를 jp로 표기하는 전환기를 위해 jp는 ja로 매핑합니다.
@@ -130,6 +150,8 @@ export function normalizeFrontmatter(data: Record<string, unknown>): ContentFron
     source_url: typeof data.source_url === 'string' ? data.source_url : undefined,
     archived_url: typeof data.archived_url === 'string' ? data.archived_url : undefined,
     reading_time: normalizeReadingTime(data.reading_time),
+    series: typeof data.series === 'string' ? data.series.trim() || undefined : undefined,
+    series_order: normalizeSeriesOrder(data.series_order),
   };
 }
 

--- a/src/libs/content/postMeta.ts
+++ b/src/libs/content/postMeta.ts
@@ -159,6 +159,8 @@ export function readExportedTranslations(contentRoot: string): PostTranslationsB
       translations[lang] = {
         title: frontmatter.title || slug,
         description: frontmatter.description || extractDescription(parsed.content) || undefined,
+        // 번역본 frontmatter의 series는 표시용 이름만 바꾸고, 그룹핑 키는 kr 원문 값을 유지합니다.
+        ...(frontmatter.series ? { seriesName: frontmatter.series } : {}),
       };
       translationsBySlug.set(slug, translations);
     }
@@ -231,6 +233,16 @@ export function createPostMetaList(
         foregroundRgb: resolveCategoryForegroundRgb(categoryText),
       },
       tags: note.frontmatter.tags || [],
+      ...(note.frontmatter.series
+        ? {
+            series: {
+              name: note.frontmatter.series,
+              ...(note.frontmatter.series_order !== undefined
+                ? { order: note.frontmatter.series_order }
+                : {}),
+            },
+          }
+        : {}),
       slug,
       encodedSlug: encodeURIComponent(slug),
       cover: note.frontmatter.cover,

--- a/src/libs/content/types.ts
+++ b/src/libs/content/types.ts
@@ -36,6 +36,14 @@ export interface ContentFrontmatter {
    * 예상 읽기 시간(분). KB frontmatter에서 주입됩니다.
    */
   reading_time?: number;
+  /**
+   * 시리즈 이름. kr 원문 값이 시리즈 그룹핑 키이고, 번역본은 표시용 이름만 다르게 가질 수 있습니다.
+   */
+  series?: string;
+  /**
+   * 시리즈 내 순서 (1부터 시작하는 양의 정수)
+   */
+  series_order?: number;
   [key: string]: unknown;
 }
 

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -573,6 +573,13 @@
   align-items: center;
 }
 
+/* 크기 지정 이미지는 trigger를 내용 폭으로 줄여야 figure의 center 정렬이 동작하고,
+   줌 아이콘도 컬럼 끝이 아닌 이미지 모서리에 붙는다 */
+.post-body .markdown-image[data-sized='true'] .markdown-image-trigger {
+  width: auto;
+  max-width: 100%;
+}
+
 .post-body .markdown-image span {
   margin-top: 0.5rem;
   color: var(--pb-muted);

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -27,6 +27,24 @@ export function langPathPrefix(lang: PostLang): string {
 export interface PostTranslationMeta {
   title: string;
   description?: string;
+  /**
+   * 번역본에 표시할 시리즈 이름. 시리즈 그룹핑 키는 kr 원문 series.name을 유지합니다.
+   */
+  seriesName?: string;
+}
+
+/**
+ * 포스트가 속한 시리즈(연재물) 메타데이터
+ */
+export interface PostSeriesMeta {
+  /**
+   * 시리즈 이름. 시리즈를 묶는 식별자이자 표시 텍스트입니다.
+   */
+  name: string;
+  /**
+   * 시리즈 내 순서 (1부터 시작). 생략 시 작성일 순으로 정렬됩니다.
+   */
+  order?: number;
 }
 
 /**
@@ -84,6 +102,11 @@ export interface PostMeta {
      */
     foregroundRgb?: string;
   };
+  /**
+   * 시리즈 정보. 같은 name을 가진 포스트들이 하나의 시리즈(글 묶음)를 이룹니다.
+   * order가 없으면 createdAt 순으로 시리즈 내 순서를 정합니다.
+   */
+  series?: PostSeriesMeta;
   /**
    * 태그 목록
    */

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -43,7 +43,7 @@ export function getPostLanguages(post: Pick<PostMeta, 'languages'>): PostLang[] 
 }
 
 /**
- * PostMeta의 title/description을 요청 언어 번역 값으로 치환합니다.
+ * PostMeta의 title/description/시리즈 표시 이름을 요청 언어 번역 값으로 치환합니다.
  * 번역이 없으면 kr 원문 값을 유지합니다.
  */
 export function localizePostMeta(post: PostMeta, lang: PostLang): PostMeta {
@@ -60,6 +60,9 @@ export function localizePostMeta(post: PostMeta, lang: PostLang): PostMeta {
     ...post,
     title: translation.title || post.title,
     description: translation.description ?? post.description,
+    ...(post.series && translation.seriesName
+      ? { series: { ...post.series, name: translation.seriesName } }
+      : {}),
   };
 }
 
@@ -109,6 +112,56 @@ export function getPostCategories(posts: PostMeta[]): string[] {
 
 export function getPostTags(posts: PostMeta[]): string[] {
   return Array.from(new Set(posts.flatMap(post => post.tags)));
+}
+
+/**
+ * 시리즈 목록 UI에 필요한 요약 정보
+ */
+export interface SeriesSummary {
+  name: string;
+  count: number;
+}
+
+/**
+ * 포스트 목록에서 시리즈 요약 목록을 파생합니다.
+ * 포스트 등장 순서를 유지하며, 포스트가 1개뿐인 시리즈도 포함합니다.
+ */
+export function getPostSeriesList(posts: PostMeta[]): SeriesSummary[] {
+  const seriesMap = new Map<string, number>();
+
+  for (const post of posts) {
+    if (!post.series) {
+      continue;
+    }
+    seriesMap.set(post.series.name, (seriesMap.get(post.series.name) ?? 0) + 1);
+  }
+
+  return Array.from(seriesMap.entries()).map(([name, count]) => ({ name, count }));
+}
+
+/**
+ * 주어진 시리즈 이름에 속한 포스트들을 시리즈 순서대로 반환합니다.
+ * series.order가 있으면 order 오름차순, 없으면 작성일 오름차순(먼저 쓴 글이 1편)입니다.
+ */
+export function getSeriesPosts(posts: PostMeta[], seriesName: string): PostMeta[] {
+  return posts
+    .filter(post => post.series?.name === seriesName)
+    .sort((a, b) => {
+      const orderA = a.series?.order;
+      const orderB = b.series?.order;
+
+      if (orderA !== undefined && orderB !== undefined && orderA !== orderB) {
+        return orderA - orderB;
+      }
+      if (orderA !== undefined && orderB === undefined) {
+        return -1;
+      }
+      if (orderA === undefined && orderB !== undefined) {
+        return 1;
+      }
+
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
 }
 
 /**

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -8,7 +8,7 @@ import type { PostMeta } from '@/types/blog';
  * 2. Run exact phrase matching inside each field only, so title/description boundaries do not
  *    create false positives.
  * 3. For typo tolerance, require every query token to match at least one token from title,
- *    description, category, or tags.
+ *    description, category, series name, or tags.
  * 4. Fuzzy matching is disabled for tokens shorter than four characters. Longer tokens use a
  *    conservative edit-distance threshold: <=5 chars allow one edit, <=8 chars allow two edits,
  *    and longer tokens allow roughly 25% edits.
@@ -46,7 +46,13 @@ export function filterPostsBySearch(posts: PostMeta[], rawQuery: string): PostMe
 }
 
 function getPostSearchFields(post: PostMeta): string[] {
-  return [post.title, post.description ?? '', post.category.text, ...post.tags];
+  return [
+    post.title,
+    post.description ?? '',
+    post.category.text,
+    post.series?.name ?? '',
+    ...post.tags,
+  ];
 }
 
 function matchesSearchToken(token: string, normalizedField: string): boolean {

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/en/published-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/en/published-note.md
@@ -6,6 +6,7 @@ title: 'Published Note (EN)'
 description: 'A published fixture note translated into English.'
 tags: [blog, fixture]
 publish: true
+series: 'Fixture Series'
 slug: published-note
 added: 2026-06-21
 published_at: 2026-06-21

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/en/second-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/en/second-note.md
@@ -6,6 +6,7 @@ title: 'Second Note (EN)'
 description: 'A second fixture post translated into English.'
 tags: [blog]
 publish: true
+series: 'Fixture Series'
 added: 2026-06-20
 published_at: 2026-06-20
 updated: 2026-06-21

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/ja/published-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/ja/published-note.md
@@ -6,6 +6,7 @@ title: '公開ノート (JP)'
 description: '日本語に翻訳された公開フィクスチャノートです。'
 tags: [blog, fixture]
 publish: true
+series: 'フィクスチャーシリーズ'
 slug: published-note
 added: 2026-06-21
 published_at: 2026-06-21

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/published-note.md
@@ -5,6 +5,8 @@ title: 'Published Note'
 description: 'A published fixture note.'
 tags: [blog, fixture]
 publish: true
+series: '픽스처 시리즈'
+series_order: 2
 slug: published-note
 added: 2026-06-21
 published_at: 2026-06-21

--- a/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/second-note.md
+++ b/tests/fixtures/kb/KNOWELDGE_BASE/dev/blog/wiki/second-note.md
@@ -5,6 +5,8 @@ title: 'Second Note'
 description: 'A second fixture post for validating the content pipeline.'
 tags: [blog]
 publish: true
+series: '픽스처 시리즈'
+series_order: 1
 added: 2026-06-20
 published_at: 2026-06-20
 updated: 2026-06-21


### PR DESCRIPTION
## 요약

블로그에 시리즈(연재물) 기능을 추가하고, 빌드 타임 이미지 최적화와 포스트 레이아웃 정합을 함께 정리했습니다.

## 시리즈 기능

velog·Dev.to 등 주요 플랫폼의 시리즈 UX 리서치를 기반으로 설계했습니다.

- **포스트 상세**: 헤더와 본문 사이의 접이식 시리즈 박스 — 시리즈 이름(세리프 악센트), 현재 위치(n / m), 펼치면 번호 목록에 현재 글 강조. 시리즈 글은 이전/다음 내비게이션이 시리즈 순서를 따릅니다.
- **블로그 목록**: 사이드바 시리즈 섹션(글 개수 표시, 재클릭 해제), `?series=` URL 필터, 카드/행 날짜 옆 시리즈 표시(Album 아이콘), 검색 결과 배너 `(Series: 이름)` 표시. 시리즈 이름은 검색 대상에도 포함됩니다.
- **데이터**: frontmatter `series`/`series_order` → postMeta 파이프라인. 번역본(index.en/ja.md)의 `series`는 언어별 표시 이름으로 쓰이고 그룹핑 키는 kr 원문을 유지합니다. kr/en/ja UI 라벨, Giscus 댓글 언어도 라우트를 따라갑니다.

## 이미지 최적화 (빌드 타임)

- 본문 래스터 이미지(png/jpg/webp)를 **1440px(표시폭 720의 레티나 2배) 상한 webp**로 변환, 커버는 OG 크롤러 호환을 위해 원본 포맷 유지 + 1536px 상한
- 비율 유지 축소만 수행(crop/업스케일 없음), GIF/SVG는 원본 복사
- content hash에 변환 파라미터 포함 → 원본 교체·설정 변경 시 캐시 자동 무효화
- 실측: `public/content/posts` **9.4MB → 3.2MB (66% 절감)**

## 레이아웃

- xl에서 본문 768px + ToC 256px = **정확히 1024px** (기존엔 컨테이너 패딩 때문에 24px 어긋남)
- 커버 박스를 고정 px 높이 대신 **1.91:1(OG 표준) 반응형 비율**로 — 폭에 따라 높이가 따라가고, 채움 방식은 기존과 동일(크롭 없이 늘려 채움)

## 검증

- `bun run verify` 전체 통과 (타입·린트·포맷·유닛 테스트·빌드·콘텐츠/링크 체크)
- 신규 컴포넌트(PostSeries, SeriesList) 스토리북 + 테스트 포함
- 시리즈가 실제 노출되려면 KNOWLEDGE_BASE frontmatter에 `series` 필드 추가 필요 (파이프라인은 준비 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)