### PR TITLE
chore(deps): bump lucide-react 0.556.0 → 1.25.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "gray-matter": "^4.0.3",
         "hast-util-to-string": "^3.0.1",
         "katex": "^0.17.0",
-        "lucide-react": "^0.556.0",
+        "lucide-react": "1.25.0",
         "mdast-util-to-string": "^4.0.0",
         "mermaid": "^11.15.0",
         "next": "16.2.10",
@@ -1371,7 +1371,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lucide-react": ["lucide-react@0.556.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A=="],
+    "lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gray-matter": "^4.0.3",
     "hast-util-to-string": "^3.0.1",
     "katex": "^0.17.0",
-    "lucide-react": "^0.556.0",
+    "lucide-react": "1.25.0",
     "mdast-util-to-string": "^4.0.0",
     "mermaid": "^11.15.0",
     "next": "16.2.10",


### PR DESCRIPTION
## 변경

- `lucide-react` ^0.556.0 → **1.25.0** (bun.lock 재생성 포함)

## 배경

dependabot #235와 동일한 업그레이드입니다. #235는 코드 문제가 아니라 **bun.lock이 main과 어긋난 상태**여서 CI의 `bun install --frozen-lockfile`이 "lockfile had changes, but lockfile is frozen"으로 실패했습니다. 이 PR은 최신 main 기준으로 lockfile을 재생성했으므로 머지 후 #235는 닫으면 됩니다.

lucide 1.x에서 이 레포가 사용하는 아이콘들(Clock, ChevronRight/Down, X, ExternalLink, ArrowUpRight, Undo2, MessagesSquare 등)은 모두 그대로 존재하며 breaking 없음을 확인했습니다.

## 검증

`bun run verify` 전체 통과 (타입·린트·포맷·유닛 테스트 718개·빌드·콘텐츠/링크 체크)

## 참고

`feat/post-series`(#236)와 `bun.lock`이 겹치므로 먼저 머지되는 쪽 이후 다른 쪽은 rebase + `bun install`이 필요할 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)