### PR TITLE
feat(blog): 이미지 나란히 배치 지원 + 시리즈 아코디언 애니메이션

### DIFF
--- a/scripts/check-content-quality.ts
+++ b/scripts/check-content-quality.ts
@@ -229,6 +229,17 @@ function checkMarkdownLinksAndImages(
     errors.push(`${relativeFile}: emphasized links must not be exported with escaped * markers.`);
   }
 
+  visit(tree, 'html', node => {
+    const html = node as { value?: string };
+    // raw HTML img는 exporter가 경로 재작성/webp 변환을 하지 못해 배포에서 깨집니다.
+    // 나란히 배치는 같은 문단에 markdown 이미지를 연속으로 쓰는 문법을 사용합니다.
+    if (typeof html.value === 'string' && /<img\s/i.test(html.value)) {
+      errors.push(
+        `${relativeFile}: raw HTML <img> is not supported (assets are not exported); use markdown image syntax instead.`,
+      );
+    }
+  });
+
   visit(tree, ['link', 'image'], node => {
     if (node.type === 'link') {
       const link = node as Link;

--- a/src/__tests__/libs/content/exporter.test.ts
+++ b/src/__tests__/libs/content/exporter.test.ts
@@ -194,6 +194,74 @@ describe('content exporter', () => {
     expect(coverMeta.height).toBe(768);
   });
 
+  it('converts raw HTML figure rows into adjacent markdown images with exported assets', async () => {
+    const { default: sharp } = await import('sharp');
+
+    const kbRoot = path.join(tempRoot, 'KB');
+    const noteDir = path.join(kbRoot, 'dev', 'blog', 'wiki');
+    fs.mkdirSync(path.join(noteDir, 'assets'), { recursive: true });
+    for (const name of ['left.png', 'right.png']) {
+      await sharp({
+        create: { width: 800, height: 600, channels: 3, background: { r: 90, g: 90, b: 90 } },
+      })
+        .png()
+        .toFile(path.join(noteDir, 'assets', name));
+    }
+    // KB에서 실제로 쓰는 나란히 배치 raw HTML 패턴 그대로
+    fs.writeFileSync(
+      path.join(noteDir, 'figure-note.md'),
+      [
+        '---',
+        'layer: wiki',
+        'title: Figure Note',
+        'publish: true',
+        'slug: figure-note',
+        'added: 2026-07-12',
+        '---',
+        '',
+        '# Figure Note',
+        '',
+        '<div style="display: flex; gap: 1rem; flex-wrap: wrap; align-items: flex-start;">',
+        '  <figure style="flex: 1 1 320px; margin: 0;">',
+        '    <img src="./assets/left.png" alt="왼쪽 alt" style="width: 100%;" />',
+        '    <figcaption>왼쪽 recall@100 vs code length</figcaption>',
+        '  </figure>',
+        '  <figure style="flex: 1 1 320px; margin: 0;">',
+        '    <img src="./assets/right.png" alt="오른쪽 alt" style="width: 100%;" />',
+        '    <figcaption>오른쪽 recall@100 vs code length</figcaption>',
+        '  </figure>',
+        '</div>',
+        '',
+        '본문 텍스트.',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const index = buildContentIndex(kbRoot);
+    const paths = createExportPaths();
+    for (const note of index.publishedNotes) {
+      exportPublishedPost(note, index, paths);
+    }
+    await flushPendingImageExports();
+
+    const slug = '2026-07-12-figure-note';
+    const markdown = fs.readFileSync(path.join(paths.contentRoot, slug, 'index.md'), 'utf8');
+
+    // raw HTML은 사라지고, figcaption을 캡션으로 쓰는 연속 markdown 이미지(같은 문단)로 변환된다
+    expect(markdown).not.toContain('<img');
+    expect(markdown).not.toContain('<figure');
+    expect(markdown).toMatch(
+      new RegExp(
+        `!\\[왼쪽 recall@100 vs code length\\]\\(/content/posts/${slug}/assets/left\\.[a-f0-9]{12}\\.webp\\)\\n` +
+          `!\\[오른쪽 recall@100 vs code length\\]\\(/content/posts/${slug}/assets/right\\.[a-f0-9]{12}\\.webp\\)`,
+      ),
+    );
+
+    // 에셋도 webp로 export된다
+    const assetsDir = path.join(tempRoot, 'public/content/posts', slug, 'assets');
+    expect(fs.readdirSync(assetsDir).filter(name => name.endsWith('.webp'))).toHaveLength(2);
+  });
+
   it('keeps small raster images at their original size', async () => {
     const { default: sharp } = await import('sharp');
 

--- a/src/__tests__/libs/content/renderMarkdown.test.tsx
+++ b/src/__tests__/libs/content/renderMarkdown.test.tsx
@@ -212,6 +212,29 @@ flowchart TD
     ).not.toBeInTheDocument();
   });
 
+  it('같은 문단의 연속 이미지 2개를 나란히 배치(row)로 렌더링한다', async () => {
+    const content = await renderMarkdownToReact(
+      `![SDC recall](/content/posts/published-note/assets/diagram.svg)
+![ADC recall](/content/posts/published-note/assets/diagram.svg)
+
+![단독 이미지](/content/posts/published-note/assets/diagram.svg)`,
+      linkMaps,
+    );
+
+    const { container } = render(<>{content}</>);
+
+    const row = container.querySelector('p.markdown-image-row');
+    expect(row).not.toBeNull();
+    // row 안에 이미지 2개, 캡션 유지
+    expect(row!.querySelectorAll('.markdown-image')).toHaveLength(2);
+    expect(screen.getByText('SDC recall')).toBeInTheDocument();
+    expect(screen.getByText('ADC recall')).toBeInTheDocument();
+
+    // 단독 이미지 문단에는 row 클래스가 붙지 않는다
+    expect(container.querySelectorAll('p.markdown-image-row')).toHaveLength(1);
+    expect(screen.getByText('단독 이미지')).toBeInTheDocument();
+  });
+
   it('applies supported markdown image size hints without leaking syntax into captions', async () => {
     const content = await renderMarkdownToReact(
       `![Alt sized|320x180](/content/posts/published-note/assets/diagram.svg)

--- a/src/components/sections/PostSeries/PostSeries.tsx
+++ b/src/components/sections/PostSeries/PostSeries.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { Album, ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import React, { useState } from 'react';
@@ -70,6 +71,7 @@ export const PostSeries = ({
   className = '',
 }: PostSeriesProps) => {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const shouldReduceMotion = useReducedMotion();
   const strings = getPostSeriesStrings(lang);
 
   const currentIndex = posts.findIndex(post => post.id === currentPostId);
@@ -115,56 +117,76 @@ export const PostSeries = ({
         </span>
       </button>
 
-      {/* 시리즈 포스트 목록 */}
-      {isExpanded && (
-        <ol className="space-y-1 px-3 pb-4">
-          {posts.map((post, index) => {
-            const isCurrent = post.id === currentPostId;
-            const rowStyles =
-              'flex items-center gap-3 rounded-md px-3 py-2.5 transition-all duration-200';
-            const rowContent = (
-              <>
-                <span
-                  className={`w-5 flex-shrink-0 text-right font-maruBuri text-sm ${
-                    isCurrent ? 'opacity-90' : 'opacity-50'
-                  }`}
-                  aria-hidden="true"
-                >
-                  {index + 1}
-                </span>
-                <Text className={`min-w-0 flex-1 truncate text-sm ${isCurrent ? 'font-bold' : ''}`}>
-                  {post.title}
-                </Text>
-                {isCurrent && (
-                  <span className="flex-shrink-0 rounded-sm bg-[color:var(--color-text)] px-2 py-0.5 text-xs text-[color:var(--color-background)]">
-                    {strings.currentPost}
-                  </span>
-                )}
-              </>
-            );
+      {/* 시리즈 포스트 목록 - 펼침/접힘을 높이 애니메이션으로 전환 */}
+      <AnimatePresence initial={false}>
+        {isExpanded && (
+          <motion.div
+            key="series-list"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : {
+                    height: { duration: 0.28, ease: [0.25, 0.1, 0.25, 1] },
+                    opacity: { duration: 0.2 },
+                  }
+            }
+            className="overflow-hidden"
+          >
+            <ol className="space-y-1 px-3 pb-4">
+              {posts.map((post, index) => {
+                const isCurrent = post.id === currentPostId;
+                const rowStyles =
+                  'flex items-center gap-3 rounded-md px-3 py-2.5 transition-all duration-200';
+                const rowContent = (
+                  <>
+                    <span
+                      className={`w-5 flex-shrink-0 text-right font-maruBuri text-sm ${
+                        isCurrent ? 'opacity-90' : 'opacity-50'
+                      }`}
+                      aria-hidden="true"
+                    >
+                      {index + 1}
+                    </span>
+                    <Text
+                      className={`min-w-0 flex-1 truncate text-sm ${isCurrent ? 'font-bold' : ''}`}
+                    >
+                      {post.title}
+                    </Text>
+                    {isCurrent && (
+                      <span className="flex-shrink-0 rounded-sm bg-[color:var(--color-text)] px-2 py-0.5 text-xs text-[color:var(--color-background)]">
+                        {strings.currentPost}
+                      </span>
+                    )}
+                  </>
+                );
 
-            return (
-              <li key={post.id}>
-                {isCurrent ? (
-                  <div
-                    className={`${rowStyles} bg-[color:var(--color-background)] shadow-sm`}
-                    aria-current="true"
-                  >
-                    {rowContent}
-                  </div>
-                ) : (
-                  <Link
-                    href={post.href}
-                    className={`${rowStyles} cursor-pointer hover:bg-[color:var(--color-secondary)] hover:shadow-sm`}
-                  >
-                    {rowContent}
-                  </Link>
-                )}
-              </li>
-            );
-          })}
-        </ol>
-      )}
+                return (
+                  <li key={post.id}>
+                    {isCurrent ? (
+                      <div
+                        className={`${rowStyles} bg-[color:var(--color-background)] shadow-sm`}
+                        aria-current="true"
+                      >
+                        {rowContent}
+                      </div>
+                    ) : (
+                      <Link
+                        href={post.href}
+                        className={`${rowStyles} cursor-pointer hover:bg-[color:var(--color-secondary)] hover:shadow-sm`}
+                      >
+                        {rowContent}
+                      </Link>
+                    )}
+                  </li>
+                );
+              })}
+            </ol>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   );
 };

--- a/src/components/sections/RelatedPosts/RelatedPosts.test.tsx
+++ b/src/components/sections/RelatedPosts/RelatedPosts.test.tsx
@@ -53,6 +53,39 @@ describe('RelatedPosts', () => {
     expect(screen.getByText('현재')).toBeInTheDocument();
   });
 
+  it('언어에 맞는 제목/개수/현재 배지를 표시한다', () => {
+    const { rerender } = render(
+      <RelatedPosts
+        posts={samplePosts}
+        category="React"
+        currentPostId={2}
+        totalPostsCount={3}
+        lang="en"
+      />,
+    );
+    expect(screen.getByText('More posts in React')).toBeInTheDocument();
+    expect(screen.getByText('3 posts')).toBeInTheDocument();
+    expect(screen.getByText('Now')).toBeInTheDocument();
+
+    rerender(
+      <RelatedPosts
+        posts={samplePosts}
+        category="React"
+        currentPostId={2}
+        totalPostsCount={1}
+        lang="ja"
+      />,
+    );
+    expect(screen.getByText('Reactの他の記事')).toBeInTheDocument();
+    expect(screen.getByText('1件')).toBeInTheDocument();
+    expect(screen.getByText('現在')).toBeInTheDocument();
+  });
+
+  it('en 빈 상태 문구를 표시한다', () => {
+    render(<RelatedPosts posts={[]} category="React" lang="en" />);
+    expect(screen.getByText('No related posts yet.')).toBeInTheDocument();
+  });
+
   it('로딩 상태를 올바르게 표시한다', () => {
     render(<RelatedPosts posts={[]} category="React" isLoading={true} postsPerPage={3} />);
 

--- a/src/components/sections/RelatedPosts/RelatedPosts.tsx
+++ b/src/components/sections/RelatedPosts/RelatedPosts.tsx
@@ -4,6 +4,9 @@ import { RelatedPostRow, type RelatedPostRowProps } from '@/components/ui/blog/R
 import { PaginationBar } from '@/components/ui/pagination/PaginationBar';
 import { Heading } from '@/components/ui/typography';
 import { DEFAULT_POSTS_PER_PAGE } from '@/constants';
+import { getRelatedPostsStrings } from '@/constants/i18n';
+import { DEFAULT_POST_LANG } from '@/types/blog';
+import type { PostLang } from '@/types/blog';
 
 export interface RelatedPostsProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /**
@@ -25,6 +28,11 @@ export interface RelatedPostsProps extends Omit<HTMLAttributes<HTMLDivElement>, 
    * 전체 포스트 개수 (제목에 "N개" 형태로 표시)
    */
   totalPostsCount?: number;
+
+  /**
+   * 렌더링 언어 (제목/개수/현재 배지/빈 상태 문구 분기)
+   */
+  lang?: PostLang;
 
   /**
    * 페이지네이션 활성화 여부
@@ -95,13 +103,14 @@ export const RelatedPosts = forwardRef<HTMLDivElement, RelatedPostsProps>(
       currentPostId,
       category,
       totalPostsCount,
+      lang = DEFAULT_POST_LANG,
       enablePagination = false,
       currentPage = 1,
       totalPages = 1,
       onPageChange,
       postsPerPage = DEFAULT_POSTS_PER_PAGE,
       isLoading = false,
-      emptyMessage = '관련 포스트가 없습니다.',
+      emptyMessage,
       showTitle = true,
       paginationSize = 'md',
       className = '',
@@ -112,8 +121,9 @@ export const RelatedPosts = forwardRef<HTMLDivElement, RelatedPostsProps>(
     // 기본 컨테이너 스타일 - 1024px 고정 너비
     const containerStyles = 'mx-auto';
 
-    // 동적 제목 생성
-    const displayTitle = `${category} 주제의 다른 글`;
+    const strings = getRelatedPostsStrings(lang);
+    // 동적 제목 생성 (언어별)
+    const displayTitle = strings.title(category);
 
     // 페이지네이션이 활성화된 경우 현재 페이지의 포스트만 표시
     const displayPosts = enablePagination
@@ -129,7 +139,7 @@ export const RelatedPosts = forwardRef<HTMLDivElement, RelatedPostsProps>(
               <Heading level={3}>{displayTitle}</Heading>
               {totalPostsCount !== undefined && (
                 <span className="ml-3 px-3 py-1 text-sm bg-[color:var(--color-secondary)] text-[color:var(--color-text)] rounded-full">
-                  {totalPostsCount}개
+                  {strings.count(totalPostsCount)}
                 </span>
               )}
             </div>
@@ -152,7 +162,9 @@ export const RelatedPosts = forwardRef<HTMLDivElement, RelatedPostsProps>(
         ) : posts.length === 0 ? (
           // 빈 상태
           <div className="flex items-center justify-center h-32 bg-[color:var(--color-primary)] border border-[color:var(--color-secondary)] rounded-md">
-            <p className="text-[color:var(--color-text)] opacity-70">{emptyMessage}</p>
+            <p className="text-[color:var(--color-text)] opacity-70">
+              {emptyMessage ?? strings.empty}
+            </p>
           </div>
         ) : (
           // 정상 상태 - 포스트 목록과 페이지네이션
@@ -167,6 +179,7 @@ export const RelatedPosts = forwardRef<HTMLDivElement, RelatedPostsProps>(
                   createdAt={post.createdAt}
                   href={post.href}
                   isCurrent={post.id === currentPostId}
+                  currentLabel={strings.currentPost}
                   className="w-full"
                 />
               ))}

--- a/src/components/templates/PostTemplate/PostTemplate.tsx
+++ b/src/components/templates/PostTemplate/PostTemplate.tsx
@@ -196,6 +196,7 @@ export const PostTemplate = ({
               posts={relatedPosts}
               currentPostId={post.id}
               category={post.category.text}
+              lang={lang}
               totalPostsCount={relatedPosts.length}
               enablePagination={enableRelatedPostsPagination}
               currentPage={relatedPostsCurrentPage}

--- a/src/components/ui/blog/RelatedPostRow/RelatedPostRow.tsx
+++ b/src/components/ui/blog/RelatedPostRow/RelatedPostRow.tsx
@@ -26,6 +26,11 @@ export interface RelatedPostRowProps {
    */
   isCurrent?: boolean;
   /**
+   * 현재 포스트 배지 라벨 (언어별)
+   * @default '현재'
+   */
+  currentLabel?: string;
+  /**
    * 추가 CSS 클래스
    */
   className?: string;
@@ -42,6 +47,7 @@ export const RelatedPostRow: React.FC<RelatedPostRowProps> = ({
   createdAt,
   href,
   isCurrent = false,
+  currentLabel = '현재',
   className = '',
 }) => {
   // 기본 스타일
@@ -71,7 +77,7 @@ export const RelatedPostRow: React.FC<RelatedPostRowProps> = ({
           </Heading>
           {isCurrent && (
             <span className="text-xs px-2 py-1 bg-[color:var(--color-text)] text-[color:var(--color-background)] rounded-sm flex-shrink-0">
-              현재
+              {currentLabel}
             </span>
           )}
         </div>

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -124,6 +124,50 @@ export function getPostSeriesStrings(lang: PostLang = DEFAULT_POST_LANG): PostSe
 }
 
 /**
+ * 포스트 상세의 관련 포스트 섹션 라벨(언어별).
+ */
+export interface RelatedPostsStrings {
+  /** 섹션 제목. 예: "{category} 주제의 다른 글" */
+  title: (category: string) => string;
+  /** 전체 개수 배지. 예: "3개" */
+  count: (count: number) => string;
+  /** 관련 포스트가 없을 때 문구 */
+  empty: string;
+  /** 목록에서 현재 글 배지 */
+  currentPost: string;
+}
+
+const LOCALIZED_RELATED_POSTS_STRINGS: Record<PostLang, RelatedPostsStrings> = {
+  kr: {
+    title: category => `${category} 주제의 다른 글`,
+    count: count => `${count}개`,
+    empty: '관련 포스트가 없습니다.',
+    currentPost: '현재',
+  },
+  en: {
+    title: category => `More posts in ${category}`,
+    count: count => (count === 1 ? '1 post' : `${count} posts`),
+    empty: 'No related posts yet.',
+    currentPost: 'Now',
+  },
+  ja: {
+    title: category => `${category}の他の記事`,
+    count: count => `${count}件`,
+    empty: '関連記事はまだありません。',
+    currentPost: '現在',
+  },
+};
+
+/**
+ * 현재 언어에 맞는 관련 포스트 섹션 라벨을 반환합니다.
+ */
+export function getRelatedPostsStrings(lang: PostLang = DEFAULT_POST_LANG): RelatedPostsStrings {
+  return (
+    LOCALIZED_RELATED_POSTS_STRINGS[lang] ?? LOCALIZED_RELATED_POSTS_STRINGS[DEFAULT_POST_LANG]
+  );
+}
+
+/**
  * 헤더 네비게이션 라벨(About/Blog, 언어별).
  */
 export interface HeaderNavStrings {

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -516,6 +516,22 @@ function extractHtmlAttribute(tag: string, name: string): string | undefined {
 }
 
 /**
+ * HTML 태그를 남김없이 제거합니다. 중첩 태그(`<scr<script>ipt>`)가 1회 치환 후
+ * 다시 태그를 만들 수 있으므로 고정점에 도달할 때까지 반복합니다.
+ */
+function stripHtmlTags(value: string): string {
+  let result = value;
+  let previous: string;
+
+  do {
+    previous = result;
+    result = result.replace(/<[^>]*>/g, '');
+  } while (result !== previous);
+
+  return result;
+}
+
+/**
  * KB에서 이미지를 나란히 배치할 때 쓰는 raw HTML 블록
  * (`<div style="display: flex...">` 안의 `<figure><img/><figcaption/></figure>` 목록)을
  * 같은 문단의 연속 markdown 이미지로 변환합니다.
@@ -565,10 +581,8 @@ function transformHtmlImageFigures(tree: Root) {
         return;
       }
 
-      const figcaption = figure
-        .match(/<figcaption\b[^>]*>([\s\S]*?)<\/figcaption>/i)?.[1]
-        ?.replace(/<[^>]+>/g, '')
-        .trim();
+      const rawFigcaption = figure.match(/<figcaption\b[^>]*>([\s\S]*?)<\/figcaption>/i)?.[1];
+      const figcaption = rawFigcaption ? stripHtmlTags(rawFigcaption).trim() : undefined;
       const alt = figcaption || extractHtmlAttribute(imgTag, 'alt') || '';
 
       images.push({ type: 'image', url: src, alt });

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -507,6 +507,88 @@ function removeDuplicateReferenceOriginalLinks(tree: Root) {
   }
 }
 
+const FIGURE_PATTERN =
+  /<figure\b[^>]*>\s*<img\b[^>]*\/?>\s*(?:<figcaption\b[^>]*>[\s\S]*?<\/figcaption>\s*)?<\/figure>/gi;
+
+function extractHtmlAttribute(tag: string, name: string): string | undefined {
+  const match = tag.match(new RegExp(`\\b${name}\\s*=\\s*"([^"]*)"`, 'i'));
+  return match?.[1];
+}
+
+/**
+ * KB에서 이미지를 나란히 배치할 때 쓰는 raw HTML 블록
+ * (`<div style="display: flex...">` 안의 `<figure><img/><figcaption/></figure>` 목록)을
+ * 같은 문단의 연속 markdown 이미지로 변환합니다.
+ *
+ * raw HTML img는 exporter의 에셋 복사/webp 변환을 타지 못하므로, 알려진 패턴은
+ * markdown 이미지 노드로 바꿔 파이프라인 전체(에셋·캡션·라이트박스·row 배치)를 태웁니다.
+ * 패턴에 맞지 않는 raw HTML은 건드리지 않고 check-content 게이트가 실패 처리합니다.
+ */
+function transformHtmlImageFigures(tree: Root) {
+  visit(tree, 'html', (node, index, parent) => {
+    const html = node as { value?: string };
+    const value = html.value;
+
+    if (!parent || typeof index !== 'number' || typeof value !== 'string') {
+      return;
+    }
+
+    const trimmed = value.trim();
+    if (
+      !/^<div\b[^>]*>/i.test(trimmed) ||
+      !/<\/div>\s*$/i.test(trimmed) ||
+      !/<img\b/i.test(trimmed)
+    ) {
+      return;
+    }
+
+    const figures = trimmed.match(FIGURE_PATTERN) ?? [];
+    if (figures.length === 0) {
+      return;
+    }
+
+    // div 안에 figure 외 다른 콘텐츠가 있으면 변환하지 않는다 (게이트가 잡도록 둔다)
+    const remainder = trimmed
+      .replace(/^<div\b[^>]*>/i, '')
+      .replace(/<\/div>\s*$/i, '')
+      .replace(FIGURE_PATTERN, '')
+      .trim();
+    if (remainder) {
+      return;
+    }
+
+    const images: Image[] = [];
+    for (const figure of figures) {
+      const imgTag = figure.match(/<img\b[^>]*\/?>/i)?.[0] ?? '';
+      const src = extractHtmlAttribute(imgTag, 'src');
+      if (!src) {
+        return;
+      }
+
+      const figcaption = figure
+        .match(/<figcaption\b[^>]*>([\s\S]*?)<\/figcaption>/i)?.[1]
+        ?.replace(/<[^>]+>/g, '')
+        .trim();
+      const alt = figcaption || extractHtmlAttribute(imgTag, 'alt') || '';
+
+      images.push({ type: 'image', url: src, alt });
+    }
+
+    const paragraphChildren: RootContent[] = [];
+    images.forEach((image, imageIndex) => {
+      if (imageIndex > 0) {
+        paragraphChildren.push(textNode('\n'));
+      }
+      paragraphChildren.push(image);
+    });
+
+    parent.children[index] = {
+      type: 'paragraph',
+      children: paragraphChildren,
+    } as RootContent;
+  });
+}
+
 export function transformMarkdownForExport(
   note: PublishedContentNote,
   index: ContentIndex,
@@ -522,6 +604,8 @@ export function transformMarkdownForExport(
   let cover = note.frontmatter.cover;
 
   normalizeKatexMathTree(tree);
+  // raw HTML figure 블록을 markdown 이미지 row로 변환 (아래 image visit에서 에셋 처리됨)
+  transformHtmlImageFigures(tree);
   transformReferenceWikilinks(tree, index, note.lang);
   removeDuplicateReferenceOriginalLinks(tree);
 

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -505,6 +505,51 @@ function remarkImageDimensions() {
   };
 }
 
+/**
+ * 같은 문단에 이미지가 2개 이상 연속으로 오면 나란히(row) 배치할 수 있도록
+ * 문단에 `markdown-image-row` 클래스를 부여하는 플러그인.
+ *
+ * ```md
+ * ![왼쪽 그림](a.png)
+ * ![오른쪽 그림](b.png)
+ * ```
+ * 처럼 빈 줄 없이 붙여 쓰면 한 문단이 되고, 이미지 사이 개행(공백 text 노드)만 허용합니다.
+ */
+function remarkImageRow() {
+  return function transformer(tree: Node) {
+    visit(tree, 'paragraph', node => {
+      const paragraph = node as MdastParent & { data?: { hProperties?: Record<string, unknown> } };
+      let imageCount = 0;
+
+      for (const child of paragraph.children) {
+        if (isMdastImageNode(child)) {
+          imageCount += 1;
+          continue;
+        }
+
+        if (isMdastTextNode(child) && !child.value.trim()) {
+          continue;
+        }
+
+        // 이미지와 개행 외 다른 콘텐츠가 섞여 있으면 일반 문단으로 둔다
+        return;
+      }
+
+      if (imageCount < 2) {
+        return;
+      }
+
+      paragraph.data = {
+        ...paragraph.data,
+        hProperties: {
+          ...paragraph.data?.hProperties,
+          className: 'markdown-image-row',
+        },
+      };
+    });
+  };
+}
+
 interface MdastPositionedNode {
   position?: {
     start?: { offset?: number };
@@ -1099,6 +1144,7 @@ export async function renderMarkdownToReact(
     .use(remarkMath)
     .use(remarkNormalizeKatexMath)
     .use(remarkImageDimensions)
+    .use(remarkImageRow)
     .use(remarkImageRawCaption)
     .use(remarkWikiLink, {
       aliasDivider: '|',

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -517,6 +517,22 @@
   align-items: stretch;
 }
 
+/* 같은 문단에 연속으로 쓴 이미지 2개+는 나란히 배치한다.
+   좁은 화면에서는 flex-wrap으로 자연스럽게 세로 스택으로 떨어진다. */
+.post-body p.markdown-image-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.post-body p.markdown-image-row .markdown-image {
+  flex: 1 1 16rem;
+  min-width: 0;
+  max-width: 100%;
+  margin: 0.5rem 0;
+}
+
 .post-body .markdown-image-trigger {
   position: relative;
   display: block;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -53,6 +53,7 @@ vi.mock('framer-motion', () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) =>
     React.createElement(React.Fragment, null, children),
   useInView: () => true,
+  useReducedMotion: () => false,
   useScroll: () => ({ scrollYProgress: { current: 0 } }),
   useSpring: (value: unknown) => value,
   useTransform: () => 0,


### PR DESCRIPTION
## 배경

프로덕션 PQ 논문 포스트에서 이미지 2개를 나란히 배치한 부분이 통째로 안 보이는 버그 수정입니다. KB에서 나란히 배치를 raw HTML(`<div style=flex><figure><img/></figure>...`)로 작성했는데, exporter가 raw HTML 속 `<img>`의 에셋 복사·경로 재작성·webp 변환을 하지 않고 렌더러도 raw HTML을 렌더링하지 않아 이미지가 사라졌습니다.

## 변경

**이미지 나란히 배치 (양방향 지원)**
- 같은 문단에 markdown 이미지를 연속으로 쓰면 자동으로 나란히(row) 배치 — 좁은 화면에서는 flex-wrap으로 세로 스택
- KB의 기존 raw HTML figure 블록은 exporter가 markdown 이미지 row로 **자동 변환** — KB 수정 없이 에셋 복사/webp/캡션(figcaption)/라이트박스 파이프라인을 그대로 탑니다
- 실제 KB로 검증: PQ 포스트 13~16번 이미지가 webp로 export되고 2개 row로 렌더링됨

**하네스/CI 보강**
- check-content 게이트: 변환되지 않은 raw HTML `<img>`가 export 결과에 남으면 실패 처리 (이번 같은 조용한 깨짐을 CI에서 차단)
- exporter figure 변환, renderMarkdown image-row 하네스 테스트 추가

**시리즈 아코디언 애니메이션**
- framer-motion AnimatePresence로 펼침/접힘 높이+opacity 전환 (0.28s ease)
- `prefers-reduced-motion` 존중

## 검증

`bun run verify` 전체 통과 (유닛 테스트 754개, 실제 KB 빌드·콘텐츠/링크 체크 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
