### PR TITLE
fix(blog): series box a11y (heading order, aria-label mismatch)

### DIFF
--- a/src/components/sections/PostSeries/PostSeries.tsx
+++ b/src/components/sections/PostSeries/PostSeries.tsx
@@ -5,7 +5,7 @@ import { Album, ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import React, { useState } from 'react';
 
-import { Heading, Text } from '@/components/ui/typography';
+import { Text } from '@/components/ui/typography';
 import { getPostSeriesStrings } from '@/constants/i18n';
 import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang } from '@/types/blog';
@@ -88,7 +88,6 @@ export const PostSeries = ({
           setIsExpanded(prev => !prev);
         }}
         aria-expanded={isExpanded}
-        aria-label={isExpanded ? strings.collapseSeries : strings.expandSeries}
         className="flex w-full cursor-pointer items-center justify-between gap-4 p-5 text-left"
       >
         <div className="min-w-0">
@@ -97,10 +96,9 @@ export const PostSeries = ({
             <Album aria-hidden="true" className="h-3.5 w-3.5" />
             {strings.seriesLabel}
           </span>
-          {/* 시리즈 이름 - 날짜/읽기 시간과 같은 세리프 악센트 */}
-          <Heading level={4} fontFamily="maruBuri" className="truncate">
-            {name}
-          </Heading>
+          {/* 시리즈 이름 - 세리프 악센트. 문서 heading 구조(h1->h2...)를 깨지 않도록
+              heading 태그 대신 span으로 표시한다 */}
+          <span className="block truncate font-maruBuri text-xl font-bold">{name}</span>
         </div>
 
         <span className="flex flex-shrink-0 items-center gap-3">


### PR DESCRIPTION
## 변경

Lighthouse 접근성 감점 중 시리즈 박스에서 발생한 2건 수정:

- 시리즈 이름을 `h4` 대신 `span`으로 표시 — 포스트 페이지의 heading 순서(h1 → h4 건너뜀) 위반 제거
- 토글 버튼의 `aria-label`(영어 고정 문구) 제거 — 보이는 텍스트(시리즈 이름·위치)가 그대로 접근성 이름이 되어 label-content-name-mismatch 해소, `aria-expanded`는 유지

#239 머지 직후 뒤늦게 push되어 누락된 커밋을 cherry-pick한 후속 PR입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)