### PR TITLE
fix(content): 공백 붙은 볼드 마커(**X **) 복구

### DIFF
--- a/src/__tests__/libs/content/exporter.test.ts
+++ b/src/__tests__/libs/content/exporter.test.ts
@@ -313,6 +313,23 @@ describe('content exporter', () => {
     expect(meta.height).toBe(300);
   });
 
+  it('repairs bold markers broken by adjacent whitespace', () => {
+    const index = buildContentIndex(fixtureKbRoot);
+    const note = index.publishedByBasename.get('published-note');
+    const broken = {
+      ...note!,
+      content:
+        note!.content +
+        '\n\n장점은 **코드가 작다**, **table lookup 8번으로 거리 계산이 끝난다 **는 점입니다.\n\n** 여는 쪽**도 고칩니다.\n',
+    };
+
+    const result = transformMarkdownForExport(broken, index, createExportPaths());
+
+    expect(result.markdown).toContain('**table lookup 8번으로 거리 계산이 끝난다** 는 점입니다.');
+    expect(result.markdown).toContain('**여는 쪽**도 고칩니다.');
+    expect(result.markdown).not.toContain('\\*\\*table');
+  });
+
   it('exports each published note to content/posts/<slug>/index.md', () => {
     const index = buildContentIndex(fixtureKbRoot);
     const paths = createExportPaths();

--- a/src/libs/content/emphasis.ts
+++ b/src/libs/content/emphasis.ts
@@ -1,0 +1,81 @@
+import type { Parent, PhrasingContent, Text } from 'mdast';
+import type { Node } from 'unist';
+import { visit } from 'unist-util-visit';
+
+/**
+ * 닫는(또는 여는) `**` 마커에 공백이 붙어 CommonMark 강조로 인정되지 못한 패턴.
+ * 예: `**끝난다 **는` — Obsidian은 볼드로 렌더링하지만 remark는 리터럴 텍스트로 남깁니다.
+ * escaped 마커(`\**`)는 건드리지 않습니다.
+ */
+const BROKEN_STRONG_PATTERN = /(?<!\\)\*\*(\s*)([^*\n]+?)(\s*)\*\*/;
+
+function isTextNode(value: unknown): value is Text {
+  return Boolean(
+    value && typeof value === 'object' && (value as { type?: unknown }).type === 'text',
+  );
+}
+
+/**
+ * remark 파싱 후에도 텍스트 노드에 리터럴로 남은 `**X **`/`** X**` 패턴을
+ * 실제 strong 노드로 복구합니다.
+ *
+ * 텍스트 노드 안에 `**`가 남아 있다는 것 자체가 CommonMark 파싱이 실패했다는 뜻이므로
+ * (성공한 강조는 strong 노드로 분리됨), 인접한 정상 볼드쌍을 오인할 위험 없이 안전합니다.
+ * 마커에 붙어 있던 공백은 강조 밖으로 옮겨 Obsidian 렌더링과 같은 간격을 유지합니다.
+ */
+export function repairBrokenStrongMarkers(tree: Node) {
+  visit(tree, 'text', (node: Node, index, parent) => {
+    if (!parent || typeof index !== 'number' || !isTextNode(node)) {
+      return;
+    }
+
+    const value = node.value;
+    if (!value.includes('**')) {
+      return;
+    }
+
+    const segments: PhrasingContent[] = [];
+    let rest = value;
+    let repaired = false;
+
+    while (rest) {
+      const match = rest.match(BROKEN_STRONG_PATTERN);
+      if (!match || match.index === undefined) {
+        break;
+      }
+
+      const [whole, leadingSpace, inner, trailingSpace] = match;
+      // 양쪽 모두 공백이 없으면 이 유틸이 고칠 패턴이 아니다 (escape 등 다른 원인)
+      if (!leadingSpace && !trailingSpace) {
+        break;
+      }
+
+      repaired = true;
+      const before = rest.slice(0, match.index) + (leadingSpace ? ' ' : '');
+      if (before) {
+        segments.push({ type: 'text', value: before });
+      }
+      segments.push({ type: 'strong', children: [{ type: 'text', value: inner }] });
+      rest = (trailingSpace ? ' ' : '') + rest.slice(match.index + whole.length);
+    }
+
+    if (!repaired) {
+      return;
+    }
+
+    if (rest) {
+      segments.push({ type: 'text', value: rest });
+    }
+
+    (parent as Parent).children.splice(index, 1, ...(segments as never[]));
+    // 새로 삽입한 노드들 다음부터 방문을 계속한다
+    return index + segments.length;
+  });
+}
+
+/**
+ * remark 플러그인 래퍼 (renderer 체인용)
+ */
+export function remarkRepairBrokenStrongMarkers() {
+  return repairBrokenStrongMarkers;
+}

--- a/src/libs/content/exporter.ts
+++ b/src/libs/content/exporter.ts
@@ -18,6 +18,7 @@ import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang } from '@/types/blog';
 
 import { deriveCategoryFromPath } from './category';
+import { repairBrokenStrongMarkers } from './emphasis';
 import { extractImageAltAtStart, unescapeMarkersInImageAlts } from './imageAlt';
 import { normalizeMarkdownImageSizeSyntax } from './imageDimensions';
 import { parseInlineMarkdownChildren } from './inlineMarkdown';
@@ -620,6 +621,8 @@ export function transformMarkdownForExport(
   normalizeKatexMathTree(tree);
   // raw HTML figure 블록을 markdown 이미지 row로 변환 (아래 image visit에서 에셋 처리됨)
   transformHtmlImageFigures(tree);
+  // 공백이 붙어 깨진 `**X **` 강조 마커를 실제 strong으로 복구
+  repairBrokenStrongMarkers(tree);
   transformReferenceWikilinks(tree, index, note.lang);
   removeDuplicateReferenceOriginalLinks(tree);
 

--- a/src/libs/content/renderMarkdown.tsx
+++ b/src/libs/content/renderMarkdown.tsx
@@ -28,6 +28,7 @@ import { Mermaid } from '@/components/ui/blog/Mermaid';
 import { DEFAULT_POST_LANG } from '@/types/blog';
 import type { PostLang, TableOfContentsItem } from '@/types/blog';
 
+import { remarkRepairBrokenStrongMarkers } from './emphasis';
 import { extractImageAltAtStart } from './imageAlt';
 import {
   DEFAULT_MARKDOWN_IMAGE_HEIGHT,
@@ -1154,6 +1155,7 @@ export async function renderMarkdownToReact(
     })
     .use(remarkResolveWikiLinks(linkMaps, lang))
     .use(remarkRepairAdjacentStrongMarkers)
+    .use(remarkRepairBrokenStrongMarkers)
     .use(remarkAlert)
     .use(remarkDetailsBlocks)
     .use(remarkRehype)


### PR DESCRIPTION
## 배경

KB(Obsidian)에서 `**table lookup 8번으로 거리 계산이 끝난다 **는`처럼 닫는(또는 여는) `**` 마커에 공백이 붙은 볼드는 Obsidian에서는 정상 렌더링되지만, CommonMark 규칙상 강조로 인정되지 않아 블로그에서 리터럴 `**`가 그대로 노출됐습니다 (PQ 논문 포스트에서 실제 발생).

## 변경

- remark 파싱 **후** 텍스트 노드에 리터럴로 남은 깨진 `**` 쌍만 실제 strong 노드로 복구합니다. 정상 파싱된 볼드는 이미 strong 노드로 분리된 뒤라, 인접 볼드쌍 사이 구간을 오인할 수 없는 안전한 지점입니다 (raw 정규식 치환 방식의 오폭 문제 회피).
- 마커에 붙어 있던 공백은 강조 밖으로 옮겨 Obsidian과 같은 간격을 유지합니다.
- escaped 마커(`\**`)는 건드리지 않습니다.
- exporter(export 시 정규화)와 renderer(방어적) 양쪽에 적용.

## 검증

- 실제 KB로 빌드해 PQ 포스트의 해당 문장이 `<strong>`으로 렌더링되고 리터럴 `**` 0건 확인
- 하네스 테스트 추가 (닫는 쪽/여는 쪽 공백 케이스), `bun run verify` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)